### PR TITLE
LMAE config done inline to prevent setting dry mass to 95kg

### DIFF
--- a/GameData/ROCapsules/PartConfigs/LEM/LEMAscent.cfg
+++ b/GameData/ROCapsules/PartConfigs/LEM/LEMAscent.cfg
@@ -68,9 +68,12 @@ PART
     stageOffset = 1
     childStageOffset = 1
     NoCrossFeedNodeKey = bottom
+    
+    // The following two keys are left out until someone figures out why the ignoreMass setting is being ignored.
+    // For now, let's just do the config in-line like the SXT ascent module does.
 
-    engineType = LMAE
-    ignoreMass = true
+    //engineType = LMAE
+    //ignoreMass = true
 	
 	INTERNAL
 	{
@@ -358,7 +361,63 @@ PART
         exhaustDamage = false
         ignitionThreshold = 0.1
         heatProduction = 20
+	minThrust = 15.57
+	maxThrust = 15.57
+	allowShutdown = True
+	EngineType = LiquidFuel
+	useEngineResponseSpeed = False
+	engineAccelerationSpeed = 0
+	engineDecelerationSpeed = 0
+	useThrustCurve = False
+	ullage = True
+	pressureFed = True
+	ignitions = 10
     }
+    MODULE
+    {
+	name = ModuleEngineConfigs
+	type = ModuleEngines
+	configuration = LMAE
+
+	CONFIG
+	{
+		name = LMAE
+		minThrust = 15.57
+		maxThrust = 15.57
+		heatProduction = 20
+		massMult = 1.0
+		ullage = True
+		pressureFed = True
+		ignitions = 10
+
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.1
+		}
+
+		PROPELLANT
+		{
+			name = Aerozine50
+			ratio = 0.5017
+			DrawGauge = True
+		}
+
+		PROPELLANT
+		{
+			name = NTO
+			ratio = 0.4983
+			DrawGauge = False
+		}
+
+		atmosphereCurve
+		{
+			key = 0 311
+			key = 1 100
+		}
+	}
+    }
+
 
     MODULE
     {


### PR DESCRIPTION
Without this fix the LM ascent module has a dry mass of 95 kg (because of RO engineconfig shenanigans), giving it an impressive ~9k dV and some serious burnout TWR. I'm sure a few will mind the fix.

The key "ignoreMass" is supposed to tell RF that it shouldn't recalc the part mass (because of the extra structure) but I couldn't figure out why it doesn't. The fix structure itself is mostly copied from the SXT ascent stage config way of doing things, which itself sort of hints at this being a hard to resolve issue for compound parts.