### PR TITLE
Set LEM mass after engine config pass

### DIFF
--- a/GameData/ROCapsules/PartConfigs/LEM/LEMAscent.cfg
+++ b/GameData/ROCapsules/PartConfigs/LEM/LEMAscent.cfg
@@ -64,13 +64,13 @@ PART
 	CrewCapacity = 2
 
     leaveCategory = True
-    fuelCrossfeed = true
+    fuelCrossfeed = True
     stageOffset = 1
     childStageOffset = 1
     NoCrossFeedNodeKey = bottom
 
     engineType = LMAE
-    ignoreMass = true
+    ignoreMass = True
 	
 	INTERNAL
 	{
@@ -783,9 +783,11 @@ PART
 
 //  ================================================================================
 //	Final Pass to Make Sure TAC does not add extra resources
+//	And also override the mass set by RO engine configs
 //  ================================================================================
 
 @PART[ROC-LEMAscent]:FOR[zzzRealismOverhaul]
 {
     !RESOURCE,*{}
+    @mass = 2.2
 }


### PR DESCRIPTION
New pull request BC clean working tree is good and all that. 

For reference: LEM dry mas is being set to 95kg which gets it's dV up to ~9k and it's TWR at burnout to something like 15. Which is cool but wrong. This patch overwrites those changes from the engineconfig pass and resets the part mass to 2200kg (wiki says 2150kg, but I assume moon rocks are accounted for in our figure?).

@lukecologne This is applying your fix which does work. I also saw your suggestion to change the case of the ignoreMass key and we may as well apply that as well if someone figures out why it's being ignored in the future.