### PR TITLE
Fixed rotation and category of LEM decoupler

### DIFF
--- a/GameData/ROCapsules/PartConfigs/LEM/LEMDecoupler.cfg
+++ b/GameData/ROCapsules/PartConfigs/LEM/LEMDecoupler.cfg
@@ -15,7 +15,7 @@ PART
 	{
 		model = ROCapsules/Assets/DECQ/LEM/LEM_Decoupler
 		scale = 1.0, 1.0, 1.0
-        rotation = 0, 180, 0
+        rotation = 0, 0, 0
 	}
 	
 	scale = 1.0
@@ -42,7 +42,7 @@ PART
 	
 	mass = 0.015
 	
-	category = Utility
+	category = Coupling
 	subcategory = 0
 	
 	tags = apollo, moon, lunar, crew, armstrong, aldrin, cm, csm, saturn, v, lem, lm, module, ascent, decoupler


### PR DESCRIPTION
Odd that the DECQ base mod had the rotation switched up on some parts but not all.