### PR TITLE
Fix Apollo CM CoM

### DIFF
--- a/GameData/ROCapsules/PartConfigs/Apollo/ApolloCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo/ApolloCM.cfg
@@ -46,7 +46,7 @@ PART
 	
 	bulkheadProfiles = size1, size2
 	
-	CoMOffset = 0.0, -0.25, 0.17
+	CoMOffset = 0.0, -0.25, 0.0
 		
 	//  ============================================================================
 	//	Title, Description, Category, Techs
@@ -202,8 +202,6 @@ PART
 		DescentModeCoM = 0, 0, 0.17
 	}
 
-	@CoMOffset = 0.0, -0.25, 0.0
-	
 	MODULE
 	{
 		name = ModuleScienceContainer


### PR DESCRIPTION
Change the value directly instead of trying to @patch it.
@x = y doesn't appear to work in a PART{}

Slightly improves the behavior of the upper RCS port, by putting its
thrust less in-line with the CoM. It still seems too weak; the thrust
direction might need tweaking