### PR TITLE
Fix BDB Apollo Decoupler Animation

### DIFF
--- a/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloDecoupler.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloDecoupler.cfg
@@ -44,15 +44,11 @@ PART
 
 	MODULE
 	{
-		name = ModuleBdbDecouplerAnimation
+		name = ModuleAnimateGeneric
 		animationName = release
-		waitForAnimation = 0.9
-		layer = 1
-		stagingEnabled = True
-		stagingToggleEnabledEditor = True
-		stagingEnableText = Decoupler: Enable Staging
-		stagingDisableText = Decoupler: Disable Staging
-		decouplerNodeID = top
+		startEventGUIName = Unlock CSM Umbilical
+		endEventGUIName = Lock CSM Umbilical
+		actionGUIName = Toggle CSM Umbilical
 	}
 	
 	MODULE
@@ -60,7 +56,10 @@ PART
 		name = ModuleDecouple
 		ejectionForce = 15
 		explosiveNodeID = top
-		stagingEnabled = False
+		stagingEnabled = True
+		stagingToggleEnabledEditor = True
+		stagingEnableText = Decoupler: Enable Staging
+		stagingDisableText = Decoupler: Disable Staging
 	}
 
 	MODULE


### PR DESCRIPTION
The umbilical unlocking animation would trigger as soon as the part was loaded and there was no way to relock it. I fixed it by separating out the animation from the decoupling action. It now works the same as the DECQ Apollo SM.