### PR TITLE
Fix Gemini realchutes config

### DIFF
--- a/GameData/ROCapsules/PartConfigs/Gemini/GeminiParachute.cfg
+++ b/GameData/ROCapsules/PartConfigs/Gemini/GeminiParachute.cfg
@@ -147,3 +147,18 @@ PART
 		useEvent = False
 	}
 }
+
+
+@PART[ROC-GeminiParachute]:AFTER[zzzRealismOverhaul]
+{
+    // RO forces all RealChuteModules to minDeploy 5000, deploy 1000,
+    // Get back our historical numbers
+    @MODULE[RealChuteModule]
+    {
+        @PARACHUTE
+        {
+            @minDeployment = 3200
+            @deploymentAlt = 2740
+        }
+    }    
+}

--- a/GameData/ROCapsules/PartConfigs/Gemini/GeminiParachuteDrogue.cfg
+++ b/GameData/ROCapsules/PartConfigs/Gemini/GeminiParachuteDrogue.cfg
@@ -150,5 +150,19 @@ PART
 		useStaging = True
 		useEvent = False
 	}
+}
 
+@PART[ROC-GeminiParachuteDrogue]:AFTER[zzzRealismOverhaul]
+{
+    // RO forces all RealChuteModules to minDeploy 5000, deploy 1000,
+    // which would make the drogue cut before it even deploys. Get back
+    // our historical numbers
+    @MODULE[RealChuteModule]
+    {
+        @PARACHUTE
+        {
+            @minDeployment = 15000
+            @deploymentAlt = 6400
+        }
+    }    
 }


### PR DESCRIPTION
RO overrides our real-world deploy altitudes; re-apply them after

(based on similar fix for apollo chutes. there might be a better trick...)