### PR TITLE
Fix Gemini's ModuleAblator->ModuleHeatshield patch

### DIFF
--- a/GameData/ROCapsules/PartConfigs/Gemini/GeminiCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/Gemini/GeminiCM.cfg
@@ -142,6 +142,7 @@ PART
 		}
 	}
 	//thermal
+	// FIXME: these are super-lunar-rated numbers, probably OP
 	MODULE
 	{
 		name = ModuleAblator
@@ -155,11 +156,6 @@ PART
 		reentryConductivity = 0.01
 		charMax = 1
 		charMin = 1
-	}
-	@MODULE[ModuleAblator]:NEEDS[DeadlyReentry]
-	{
-		@name = ModuleHeatShield
-		depletedMaxTemp = 1200
 	}
 	RESOURCE
 	{
@@ -229,6 +225,17 @@ PART
 		%kerbalScale = 1.219, 1.194, 1.219
 		%kerbalOffset = 0.0, 0.0, 0.0
 		%kerbalEyeOffset = 0.0, 0.0, 0.0
+	}
+}
+
+// need to convert to ModuleHeatShield before DRE runs, it would
+// replace all our values by weaker defaults
+@PART[ROC-GeminiCM]:BEFORE[DeadlyReentry]:NEEDS[DeadlyReentry]
+{
+	@MODULE[ModuleAblator]
+	{
+		@name = ModuleHeatShield
+		depletedMaxTemp = 1200
 	}
 }
 


### PR DESCRIPTION
@MODULE[...]{} don't work in a new PART{}, they just get
spit out into the MM cache as-is. Move the patch into its
own @PART; make sure it runs before DeadlyReentry's own
convert-and-change-values patch runs.

This restores Gemini to the AdvanceCommandPod-level shield
performance it was intended to have. There's a good chance that's
TOO good (only 31 units consumed on lunar reentry, in a recent
test); if so, the values should be revisited for both capsules
(and perhaps MH Gemini)