### PR TITLE
Fix APAS95 passive

### DIFF
--- a/GameData/ROCapsules/PartConfigs/APAS/APAS_Passive.cfg
+++ b/GameData/ROCapsules/PartConfigs/APAS/APAS_Passive.cfg
@@ -46,7 +46,7 @@ PART
 	
 	tags = ISS APAS docking PMA tantares loaf bread apollo kane ets
 
-	@MODULE
+	MODULE
 	{
 		name = ModuleDockingNode
 		nodeType = APAS8995


### PR DESCRIPTION
Fix a typo that caused the APAS passive port to not work.