### PR TITLE
Adjust Gemini Chute mass

### DIFF
--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiCM.cfg
@@ -35,7 +35,7 @@ PART
 	title = Gemini Command Pod
 	manufacturer = McDonnell Aircraft
 	description = The Gemini cabin. Contains two astronauts.
-	mass = 0.9211
+	mass = 1.0377
 	dragModelType = default
 	maximum_drag = 0.20
 	minimum_drag = 0.15

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiParachute.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiParachute.cfg
@@ -30,7 +30,7 @@ PART
 	title = Gemini Landing Parachute System
 	manufacturer = Parasystems, Inc.
 	description	 = Main parachute for Gemini
-	mass = 0.123
+	mass = 0.049
 	dragModelType = default
 	maximum_drag = 0.20
 	minimum_drag = 0.20
@@ -79,7 +79,7 @@ PART
 	MODULE:NEEDS[RealChute]
 	{
 		name = RealChuteModule
-		caseMass = 0.0931
+		caseMass = 0.049
 		timer = 0
 		mustGoDown = true
 		spareChutes = 0

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiParachuteDrogue.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiParachuteDrogue.cfg
@@ -36,7 +36,7 @@
 	manufacturer = Parasystems, Inc.
 	description = Drogue parachute for the Gemini capsule. Attach to the node in the nose section.
 	attachRules = 1,0,0,1,0
-	mass = 0.0746
+	mass = 0.032
 	dragModelType = default
 	angularDrag = 3
 	crashTolerance = 12
@@ -74,7 +74,7 @@
 	MODULE:NEEDS[RealChute]
 	{
 		name = RealChuteModule
-		caseMass = 0.073
+		caseMass = 0.032
 		timer = 0
 		mustGoDown = false
 		spareChutes = 1


### PR DESCRIPTION
Adjust the Gemini parachute mass to more sane values (based on RealChutes of similar size). The excess mass has been added to the Gemini CM in order to keep the total spacecraft mass the same.