### PR TITLE
Add warning about Gemini scrubber for RP-1 players

### DIFF
--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiCM.cfg
@@ -380,7 +380,7 @@ PART
 // Add disclaimer about Early Life Support and ISRU node when RP-1 is installed
 @PART[ROC-GeminiCMBDB]:BEFORE[RP-0]
 {
-		@description ^=:$: The Gemini cabin. Contains two astronauts. The Early Life Support and ISRU node is required to enable the built-in scrubber.
+		@description ^=:$: <b><color=red>The Early Life Support and ISRU node is required to enable the built-in scrubber.</color></b>
 }
 //	================================================================================
 //	Final Pass to Make Sure TAC does not add extra resources

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiCM.cfg
@@ -244,7 +244,7 @@ PART
 			uiGroupDisplayName = Command
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
@@ -375,6 +375,12 @@ PART
 			maxAmount = 29	// 14 days
 		}
 	}
+}
+
+// Add disclaimer about Early Life Support and ISRU node when RP-1 is installed
+@PART[ROC-GeminiCMBDB]:BEFORE[RP-0]
+{
+		@description ^=:$: The Gemini cabin. Contains two astronauts. The Early Life Support and ISRU node is required to enable the built-in scrubber.
 }
 //	================================================================================
 //	Final Pass to Make Sure TAC does not add extra resources


### PR DESCRIPTION
Credit to Stonesmile on Discord for letting me know how to do this.
Tested personally in installs with and without RP-1. As intended, warning only shows up in Gemini description for the RP-1 install.