### PR TITLE
Fix Orion HS and nodes

### DIFF
--- a/GameData/ROCapsules/PartConfigs/Orion/OrionCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/Orion/OrionCM.cfg
@@ -14,13 +14,7 @@ PART
 		scale = 1, 1, 1
 		rotation = 0, 180, 0
 	}
-	MODEL
-	{
-		model = ROCapsules/Assets/DECQ/Orion/HEAT_SHEALD
-		scale = 1, 1, 1
-		position = 0.0, 0.0, 0.0
-	}
-	
+
 	//	 Linear positive pitch thruster.
 
 	MODEL
@@ -45,7 +39,7 @@ PART
 	specPower = 500.1
 
 	node_stack_top = 0.0, 1.491405, 0.0, 0.0, 1.0, 0.0, 1
-	node_stack_bottom = 0.0, -0.9842814, 0.0, 0.0, -1.0, 0.0, 2
+	node_stack_bottom = 0.0, -0.2842814, 0.0, 0.0, -1.0, 0.0, 2
 	node_stack_PARA = 0.0, 1.822791, 0.0, 0.0, 1.0, 0.0, 0
 	//node_stack_PARA2 = 0.0, 1.63239, 0.0, 0.0, 1.0, 0.0, 0
 
@@ -63,8 +57,8 @@ PART
 	attachRules = 1,0,1,1,0
 
 	// --- standard part parameters ---
-	//total empty mass with 600kg of crew = 9.299. Subtract 1,360t of ablator and 600 kg of maximum crew and 206kg of extra ECLSS
-	mass = 7.940
+	//total empty mass with 600kg of crew = 9.299. Subtract 1,801 kg of HS and 600 kg of maximum crew and 206kg of extra ECLSS
+	mass = 6.692
 	dragModelType = default
 	maximum_drag = 0.3
 	minimum_drag = 0.2
@@ -217,45 +211,6 @@ PART
 			amount = 168
 			maxAmount = 168
 		}
-	}
-	
-	MODULE:NEEDS[!DeadlyReentry]
-	{
-		name = ModuleAblator
-		ablativeResource = Ablator
-		outputResource = CharredAblator
-		outputMult = 0.75
-		lossExp = -40000
-		lossConst = 15000
-		pyrolysisLossFactor = 40000
-		ablationTempThresh = 500
-		reentryConductivity = 0.01
-	}
-	
-	MODULE:NEEDS[DeadlyReentry]
-	{
-		name = ModuleHeatShield
-		ablativeResource = Ablator
-		outputResource = CharredAblator
-		outputMult = 0.75
-		lossExp = -40000
-		lossConst = 15000
-		pyrolysisLossFactor = 40000
-		ablationTempThresh = 500
-		reentryConductivity = 0.01
-		depletedMaxTemp = 4800	//2650C
-	}
-	RESOURCE
-	{
-		name = Ablator
-		amount = 600
-		maxAmount = 600
-	}
-	RESOURCE
-	{
-		name = CharredAblator
-		amount = 0
-		maxAmount = 450
 	}
 	
 	EFFECTS

--- a/GameData/ROCapsules/PartConfigs/Orion/OrionESM.cfg
+++ b/GameData/ROCapsules/PartConfigs/Orion/OrionESM.cfg
@@ -73,7 +73,7 @@ PART
 
 	node_stack_top = 0.0, 0.6595054, 0.0, 0.0, 1.0, 0.0, 1
 	node_stack_bottom = 0.0, -2.072776, 0.0, 0.0, -1.0, 0.0, 2
-	node_stack_ENG = 0.0, -0.87, 0.0, 0.0, -1.0, 0.0, 1
+	node_stack_ENG = 0.0, -1.2, 0.0, 0.0, -1.0, 0.0, 1
 
 	node_stack_12 = -1.503487, 0.7821556, -2.246316, 0.0, 1.0, 0.0, 1
 	node_stack_11 = 2.736962, 0.7821556, -0.06109023, 0.0, 1.0, 0.0, 1
@@ -203,8 +203,6 @@ PART
 		falloff = 1.2
 		thrustTransformName = newThrustTransform
 	}
-
-	PhysicsSignificance = 1
 }
 //Since the engine config will overwrite everything, add the rest of the SM afterwards
 @PART[ROC-OrionESM]:AFTER[RealismOverhaulEngines]
@@ -255,10 +253,20 @@ PART
 			maxAmount = 4031.3
 		}
 	}
+
 	MODULE
 	{
 		name = ModuleDecouple
 		ejectionForce = 150
 		explosiveNodeID = top
+	}
+
+	//make sure crossfeed is enabled (otherwise RCS won't work?)
+	MODULE
+	{
+		name = ModuleToggleCrossfeed
+		crossfeedStatus = true
+		toggleEditor = true
+		toggleFlight = true
 	}
 }

--- a/GameData/ROCapsules/PartConfigs/Orion/OrionHS.cfg
+++ b/GameData/ROCapsules/PartConfigs/Orion/OrionHS.cfg
@@ -60,42 +60,10 @@ PART
 	fuelCrossFeed = False
 	bulkheadProfiles = size0 
 
-	MODULE:NEEDS[!DeadlyReentry]
-	{
-		name = ModuleAblator
-		ablativeResource = Ablator
-		outputResource = CharredAblator
-		outputMult = 0.75
-		lossExp = -40000
-		lossConst = 15000
-		pyrolysisLossFactor = 40000
-		ablationTempThresh = 500
-		reentryConductivity = 0.01
-	}
-	
-	MODULE:NEEDS[DeadlyReentry]
-	{
-		name = ModuleHeatShield
-		ablativeResource = Ablator
-		outputResource = CharredAblator
-		outputMult = 0.75
-		lossExp = -40000
-		lossConst = 15000
-		pyrolysisLossFactor = 40000
-		ablationTempThresh = 500
-		reentryConductivity = 0.01
-		depletedMaxTemp = 4800	//2650C
-	}
-	RESOURCE
-	{
-		name = Ablator
-		amount = 600
-		maxAmount = 600
-	}
-	RESOURCE
-	{
-		name = CharredAblator
-		amount = 0
-		maxAmount = 450
-	}
+
+	//use new heat shield tagging system to configure the shield instead
+	resetHeatShieldMass = True
+	resetHeatShieldAblator = True
+	heatShieldTag = Lunar
+	heatShieldDiameter = 4.9
 }


### PR DESCRIPTION
Separate the Orion Heat Shield from the capsule, and adjust the nodes for the new ROE AJ10-190.

Note: With the current FAR release the Heat shield does not occlude the capsule at all, and the capsule takes the full reentry heating. Someone with DRVeyls FAR occlusion fix should probably test this to make sure the HS works.