### PR TITLE
Adjust Apollo ETS Part Temps

### DIFF
--- a/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloActiveDockingMechanism.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloActiveDockingMechanism.cfg
@@ -31,7 +31,8 @@ PART
 	crashTolerance = 8
 	breakingForce = 150
 	breakingTorque = 150
-	maxTemp = 3000
+	maxTemp = 673.15
+	skinMaxTemp = 773.15
 	fuelCrossFeed = false
 	stagingIcon = DECOUPLER_VERT
 	bulkheadProfiles = size0

--- a/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloDecoupler.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloDecoupler.cfg
@@ -34,7 +34,8 @@ PART
 	crashTolerance = 9
 	breakingForce = 200
 	breakingTorque = 200
-	maxTemp = 1973.15
+	maxTemp = 673.15
+	skinMaxTemp = 773.15
 	fuelCrossFeed = False
 	stageOffset = 1
 	childStageOffset = 1

--- a/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloHGABlockIII.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloHGABlockIII.cfg
@@ -29,7 +29,8 @@ PART
 	minimum_drag = 0.2
 	angularDrag = 2
 	crashTolerance = 7
-	maxTemp = 1973.15
+	maxTemp = 673.15
+	skinMaxTemp = 773.15
 	PhysicsSignificance = 1
 	bulkheadProfiles = srf
 	

--- a/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloMissionModule.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloMissionModule.cfg
@@ -31,7 +31,8 @@ PART
 	crashTolerance = 4
 	breakingForce = 200
 	breakingTorque = 200
-	maxTemp = 1973.15
+	maxTemp = 673.15
+	skinMaxTemp = 773.15
 	skinMaxTemp = 2000
 	vesselType = Ship
 	bulkheadProfiles = size2

--- a/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloSolar.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloSolar.cfg
@@ -25,7 +25,8 @@ PART
 	minimum_drag = 0.2
 	angularDrag = 1
 	crashTolerance = 8
-	maxTemp = 1200 // = 3200
+	maxTemp = 673.15
+	skinMaxTemp = 773.15
 	bulkheadProfiles = srf
 	thermalMassModifier = 2.0
 	emissiveConstant = 0.95


### PR DESCRIPTION
Adjust the Apollo ETS part temps to sane values (they were previously set to stock temp tolerances, which apparently allowed them to survive reentry unshielded).