### PR TITLE
Don't give BigG a DataTransmitter with RA either

### DIFF
--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/BigG/BigGeminiCabin.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/BigG/BigGeminiCabin.cfg
@@ -149,18 +149,4 @@ PART
 			}
 		}
 	}
-
-	MODULE:NEEDS[!RemoteTech,!RealAntennas]
-	{
-		name = ModuleDataTransmitter
-		antennaType = INTERNAL
-		packetInterval = 1.0
-		packetSize = 2
-		packetResourceCost = 12.0
-		requiredResource = ElectricCharge
-		antennaPower = 5000
-		optimumRange = 2500
-		packetFloor = .1
-		packetCeiling = 5
-	}
 }

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/BigG/BigGeminiCabin.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/BigG/BigGeminiCabin.cfg
@@ -150,7 +150,7 @@ PART
 		}
 	}
 
-	MODULE:NEEDS[!RemoteTech]
+	MODULE:NEEDS[!RemoteTech,!RealAntennas]
 	{
 		name = ModuleDataTransmitter
 		antennaType = INTERNAL


### PR DESCRIPTION
RA only converts ModuleDataTransmitter into a ModuleRealAntenna on
parts that also have a ModuleCommand, which BigG doesn't.

No idea what giving it a ModuleCommand would do, so simply not giving
it a MDT is the simple fix