### PR TITLE
Add Waterfall support for all parts.

### DIFF
--- a/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloEngineBlockIII.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloEngineBlockIII.cfg
@@ -121,7 +121,7 @@ PART
 //	Block III SPS plume configuration.
 //	==================================================
 
-@PART[ROC-ApolloEngineBlockIII]:BEFORE[RealPlume]
+@PART[ROC-ApolloEngineBlockIII]:BEFORE[RealPlume]:NEEDS[!Waterfall]
 {
 	PLUME
 	{

--- a/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloEngineBlockV.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloEngineBlockV.cfg
@@ -116,7 +116,7 @@ PART
 	%manufacturer = TRW
 	@description = Deeply throttleable pressure-fed vacuum engine used for the descent module of the Apollo lunar lander. Uses storable propellants which are not subject to boil-off, but are far less efficient than hydrolox or even kerolox. The later variant (TR-201) was used on Delta as an upper stage engine (on Delta P series); this was a low-cost model with more restarts (4 instead of 2) and slightly higher thrust but lower efficiency and no throttling capability. In the alternate Eyes Turned Skyward universe it was used for the Apollo Block V Service Module. FICTIONAL (Eyes Turned Skyward)
 
-	@MODULE[ModuleEngineConfigs] 
+	@MODULE[ModuleEngineConfigs]
 	{
 		@configuration = TR-201
 		!CONFIG[LMDE-H] {}
@@ -133,7 +133,7 @@ PART
 //	Block V SPS plume configuration.
 //	==================================================
 
-@PART[ROC-ApolloEngineBlockV]:BEFORE[RealPlume]
+@PART[ROC-ApolloEngineBlockV]:BEFORE[RealPlume]:NEEDS[!Waterfall]
 {
 	PLUME
 	{

--- a/GameData/ROCapsules/PartConfigs/Apollo ETS/Waterfall_Support_ApolloETS.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo ETS/Waterfall_Support_ApolloETS.cfg
@@ -1,0 +1,39 @@
+@PART[ROC-ApolloCMBlockIII]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = waterfall-rcs-jet-1
+        audio = rcs-jet-1
+        transform = RCSthruster
+        position = 0,0,0
+        rotation = 0,0,180
+        scale = 1,1,1
+    }
+}
+
+@PART[ROC-ApolloEngineBlockIII]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = waterfall-hypergolic-aerozine50-upper-1
+        audio = pressure-fed-1
+        position = 0,0,0.47
+        rotation = 0, 0, 0
+        scale = 0.67, 0.67, 0.67
+        glow = ro-hypergolic-az50
+    }
+}
+
+
+@PART[ROC-ApolloEngineBlockV]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = waterfall-hypergolic-aerozine50-upper-1
+        audio = pressure-fed-1
+        position = 0,0,0.75
+        rotation = 0, 0, 0
+        scale = 0.98, 0.98, 0.98
+        glow = ro-hypergolic-az50
+    }
+}

--- a/GameData/ROCapsules/PartConfigs/Apollo ETS/Waterfall_Support_ApolloETS.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo ETS/Waterfall_Support_ApolloETS.cfg
@@ -2,7 +2,7 @@
 {
     ROWaterfall
     {
-        template = waterfall-rcs-jet-1
+        template = rowaterfall-rcs-cold-gas-1
         audio = rcs-jet-1
         transform = RCSthruster
         position = 0,0,0

--- a/GameData/ROCapsules/PartConfigs/Apollo/Waterfall_Support_Apollo.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo/Waterfall_Support_Apollo.cfg
@@ -2,7 +2,7 @@
 {
     ROWaterfall
     {
-        template = waterfall-rcs-jet-1
+        template = rowaterfall-rcs-cold-gas-1
         audio = rcs-jet-1
         transform = RCSthruster
         position = 0,0.03,0
@@ -15,11 +15,11 @@
 {
     ROWaterfall
     {
-        template = waterfall-rcs-jet-1
+        template = rowaterfall-rcs-hypergolic-1
         audio = rcs-jet-1
         transform = RCSthruster
-        position = 0,0,0
-        rotation = 0,0,180
-        scale = 1,1,1
+        position = 0,0.05,0
+        rotation = 0, 0, 180
+        scale = 1.7, 1.7, 1.7
     }
 }

--- a/GameData/ROCapsules/PartConfigs/Apollo/Waterfall_Support_Apollo.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo/Waterfall_Support_Apollo.cfg
@@ -1,0 +1,25 @@
+@PART[ROC-ApolloCM]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = waterfall-rcs-jet-1
+        audio = rcs-jet-1
+        transform = RCSthruster
+        position = 0,0.03,0
+        rotation = 0, 0, 180
+        scale = 1.5, 1.5, 1.5
+    }
+}
+
+@PART[ROC-ApolloRCS]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = waterfall-rcs-jet-1
+        audio = rcs-jet-1
+        transform = RCSthruster
+        position = 0,0,0
+        rotation = 0,0,180
+        scale = 1,1,1
+    }
+}

--- a/GameData/ROCapsules/PartConfigs/CST/CSTRS88.cfg
+++ b/GameData/ROCapsules/PartConfigs/CST/CSTRS88.cfg
@@ -98,7 +98,7 @@ PART
 //	CST RealPlume Support
 //	============================================================================
 
-@PART[ROC-CSTRS88]:BEFORE[RealPlume]:NEEDS[SmokeScreen,!Waterfall]
+@PART[ROC-CSTRS88]:BEFORE[RealPlume]:NEEDS[!Waterfall]
 {
 	PLUME
 	{

--- a/GameData/ROCapsules/PartConfigs/CST/CSTRS88.cfg
+++ b/GameData/ROCapsules/PartConfigs/CST/CSTRS88.cfg
@@ -98,7 +98,7 @@ PART
 //	CST RealPlume Support
 //	============================================================================
 
-@PART[ROC-CSTRS88]:BEFORE[RealPlume]:NEEDS[SmokeScreen]
+@PART[ROC-CSTRS88]:BEFORE[RealPlume]:NEEDS[SmokeScreen,!Waterfall]
 {
 	PLUME
 	{

--- a/GameData/ROCapsules/PartConfigs/CST/Waterfall_Support_CST.cfg
+++ b/GameData/ROCapsules/PartConfigs/CST/Waterfall_Support_CST.cfg
@@ -2,7 +2,7 @@
 {
     ROWaterfall
     {
-        template = waterfall-rcs-jet-1
+        template = rowaterfall-rcs-cold-gas-1
         audio = rcs-jet-1
         transform = RCS
         position = 0,0,0
@@ -15,7 +15,7 @@
 {
     ROWaterfall
     {
-        template = waterfall-rcs-jet-1
+        template = rowaterfall-rcs-hypergolic-1
         audio = rcs-jet-1
         transform = RCS
         position = 0,0,0

--- a/GameData/ROCapsules/PartConfigs/CST/Waterfall_Support_CST.cfg
+++ b/GameData/ROCapsules/PartConfigs/CST/Waterfall_Support_CST.cfg
@@ -1,0 +1,49 @@
+@PART[ROC-CSTCM]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = waterfall-rcs-jet-1
+        audio = rcs-jet-1
+        transform = RCS
+        position = 0,0,0
+        rotation = 0, 0, 180
+        scale = 0.8, 0.8, 1
+    }
+}
+
+@PART[ROC-CSTSM]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = waterfall-rcs-jet-1
+        audio = rcs-jet-1
+        transform = RCS
+        position = 0,0,0
+        rotation = 0, 0, 180
+        scale = 1.1, 1.1, 1.1
+    }
+}
+
+@PART[ROC-CST?M]:AFTER[zROWaterfall_99_Finalize]:NEEDS[Waterfall]
+{
+    @EFFECTS
+    {
+        @running
+        {
+            |_ = rcs
+        }
+    }
+}
+
+@PART[ROC-CSTRS88]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = rowaterfall-hypergolic-superdraco
+        audio = pressure-fed-1
+        position = 0,0,0.84
+        rotation = 0, 0, 0
+        scale = 0.39, 0.39, 0.5
+        glow = _orange
+    }
+}

--- a/GameData/ROCapsules/PartConfigs/Dynasoar/RP_Dyna.cfg
+++ b/GameData/ROCapsules/PartConfigs/Dynasoar/RP_Dyna.cfg
@@ -1,4 +1,4 @@
-@PART[ROC-DynaAftBay]:BEFORE[RealPlume]
+@PART[ROC-DynaAftBay]:BEFORE[RealPlume]:NEEDS[!Waterfall]
 {
 	PLUME
 	{

--- a/GameData/ROCapsules/PartConfigs/Dynasoar/Waterfall_Support_Dynasoar.cfg
+++ b/GameData/ROCapsules/PartConfigs/Dynasoar/Waterfall_Support_Dynasoar.cfg
@@ -2,7 +2,7 @@
 {
     ROWaterfall
     {
-        template = waterfall-rcs-jet-1
+        template = rowaterfall-rcs-cold-gas-1
         audio = rcs-jet-1
         transform = RCSTHRUSTER
         position = 0,0,0
@@ -40,10 +40,5 @@
         emissionMult = 0.5
         energy = 1.0
         speed = 1.0
-    }
-
-    @MODULE[ModuleEngines*]
-    {
-        %powerEffectName = Solid-Lower
     }
 }

--- a/GameData/ROCapsules/PartConfigs/Dynasoar/Waterfall_Support_Dynasoar.cfg
+++ b/GameData/ROCapsules/PartConfigs/Dynasoar/Waterfall_Support_Dynasoar.cfg
@@ -1,0 +1,49 @@
+@PART[ROC-DynaBody|ROC-DynaAftBay|ROC-DynaWing*]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = waterfall-rcs-jet-1
+        audio = rcs-jet-1
+        transform = RCSTHRUSTER
+        position = 0,0,0
+        rotation = 0, 0, 180
+        scale = 1.1, 1.1, 1.1
+    }
+}
+
+@PART[ROC-DynaBody|ROC-DynaAftBay|ROC-DynaWing*]:AFTER[zROWaterfall_99_Finalize]:NEEDS[Waterfall]
+{
+    @EFFECTS
+    {
+        @running
+        {
+            |_ = runningrcs
+        }
+    }
+}
+
+@PART[ROC-DynaAftBay]:AFTER[ROWaterfall]:NEEDS[Waterfall]
+{
+    PLUME
+    {
+        name = Solid-Lower
+        transformName = thrustTransform
+        plumePosition = -0.05, 0.0, 0.0
+        plumeScale = 0.2
+        flarePosition = -0.05, 0.0, -0.1
+        flareScale = 0.2
+        smokePosition = -0.05, 0.0, -0.1
+        smokeScale = 0.2
+        slagPosition = -0.05, 0.0, -0.1
+        slagScale = 0.2
+        localRotation = 0.0, 0.0, 0.0
+        emissionMult = 0.5
+        energy = 1.0
+        speed = 1.0
+    }
+
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = Solid-Lower
+    }
+}

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/Waterfall_Support_GeminiBDB.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/Waterfall_Support_GeminiBDB.cfg
@@ -2,7 +2,7 @@
 {
     ROWaterfall
     {
-        template = waterfall-rcs-jet-1
+        template = rowaterfall-rcs-hypergolic-1
         audio = rcs-jet-1
         transform = rcsTransform
         position = 0,0,0
@@ -70,7 +70,7 @@
 {
     ROWaterfall
     {
-        template = waterfall-rcs-jet-1
+        template = rowaterfall-rcs-hypergolic-1
         audio = rcs-jet-1
         transform = rcsTransform
         position = 0,0,0
@@ -95,7 +95,7 @@
     ROWaterfall
     {
         moduleID = #$/name$-translate
-        template = waterfall-rcs-jet-1
+        template = rowaterfall-rcs-hypergolic-1
         audio = rcs-jet-1
         transform = rcsTransform
         position = 0,0,0
@@ -107,7 +107,7 @@
 {
     +MODULE[ModuleWaterfallFX]
     {
-        !__ro_waterfall = delete
+        !__rowaterfall = delete
         @moduleID = #$/name$-retro
         @CONTROLLER[rcs]
         {
@@ -115,7 +115,7 @@
         }
         @TEMPLATE
         {
-            !__ro_waterfall = delete
+            !__rowaterfall = delete
             @overrideParentTransform = retroTransform
         }
     }

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/Waterfall_Support_GeminiBDB.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/Waterfall_Support_GeminiBDB.cfg
@@ -1,0 +1,134 @@
+@PART[ROC-GeminiEquipmentSectionBDB]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = waterfall-rcs-jet-1
+        audio = rcs-jet-1
+        transform = rcsTransform
+        position = 0,0,0
+        rotation = 0, 0, 180
+        scale = 0.7, 0.7, 0.7
+    }
+}
+@PART[ROC-GeminiEquipmentSectionBDB]:AFTER[zROWaterfall_99_Finalize]:NEEDS[Waterfall]
+{
+    @EFFECTS
+    {
+        @running
+        {
+            |_ = rcsAtt
+        }
+    }
+}
+
+
+@PART[ROC-GeminiOAMS*BDB]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = waterfall-hypergolic-white-upper-1
+        audio = rcs-jet-1
+        transform = thrustTransform
+        position = 0,0.025,-0.015
+        rotation = 0, 0, 0
+        scale = 0.07, 0.07, 0.1
+
+        ExtraTemplate
+        {
+            template = rowaterfall-glow-hypergolic-white
+            position = 0,0.0065,0.0209
+            rotation = -26.1, 0, 0
+            scale = 0.12, 0.15, 0
+        }
+    }
+}
+@PART[ROC-GeminiOAMSRCSBDB]:AFTER[zROWaterfall_99_Finalize]:NEEDS[Waterfall]
+{
+    @MODULE[ModuleWaterfallFX]
+    {
+        @CONTROLLER[throttle]
+        {
+            @linkedTo = rcs
+            thrusterTransformName = thrustTransform
+            !engineID = delete
+        }
+    }
+}
+@PART[ROC-GeminiOAMS*BDB]:AFTER[zROWaterfall_99_Finalize]:NEEDS[Waterfall]
+{
+    @EFFECTS
+    {
+        @running
+        {
+            |_ = runningRCS
+        }
+    }
+}
+
+
+@PART[ROC-ReentryControlSystemBDB]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = waterfall-rcs-jet-1
+        audio = rcs-jet-1
+        transform = rcsTransform
+        position = 0,0,0
+        rotation = 0, 0, 180
+        scale = 0.5, 0.5, 0.5
+    }
+}
+@PART[ROC-ReentryControlSystemBDB]:AFTER[zROWaterfall_99_Finalize]:NEEDS[Waterfall]
+{
+    @EFFECTS
+    {
+        @running
+        {
+            |_ = rcsAtt
+        }
+    }
+}
+
+
+@PART[ROC-GeminiRetrogradeSectionBDB]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        moduleID = #$/name$-translate
+        template = waterfall-rcs-jet-1
+        audio = rcs-jet-1
+        transform = rcsTransform
+        position = 0,0,0
+        rotation = 0,0,180
+        scale = 1,1,1
+    }
+}
+@PART[ROC-GeminiRetrogradeSectionBDB]:AFTER[zROWaterfall_99_Finalize]:NEEDS[Waterfall]
+{
+    +MODULE[ModuleWaterfallFX]
+    {
+        !__ro_waterfall = delete
+        @moduleID = #$/name$-retro
+        @CONTROLLER[rcs]
+        {
+            @thrusterTransformName = retroTransform
+        }
+        @TEMPLATE
+        {
+            !__ro_waterfall = delete
+            @overrideParentTransform = retroTransform
+        }
+    }
+
+    @EFFECTS
+    {
+        +running
+        {
+            |_ = rcsTranslate
+        }
+        @running
+        {
+            |_ = rcsRetro
+        }
+    }
+}

--- a/GameData/ROCapsules/PartConfigs/LEM/LEM-LMDE.cfg
+++ b/GameData/ROCapsules/PartConfigs/LEM/LEM-LMDE.cfg
@@ -131,7 +131,7 @@ PART
 				speed = 1.0 1.0
 				//localOffset = 0, 0, 1
 			}
-		}	
+		}
 		engage
 		{
 			AUDIO
@@ -159,7 +159,7 @@ PART
 				pitch = 2.0
 				loop = false
 			}
-		}	
+		}
 	}
 }
 
@@ -167,7 +167,7 @@ PART
 //	Lunar Module Descent Engine plume configuration.
 //	==================================================
 
-@PART[ROC-LEM-LMDE]:BEFORE[RealPlume]
+@PART[ROC-LEM-LMDE]:BEFORE[RealPlume]:NEEDS[!Waterfall]
 {
 	PLUME
 	{

--- a/GameData/ROCapsules/PartConfigs/LEM/LEMAscent.cfg
+++ b/GameData/ROCapsules/PartConfigs/LEM/LEMAscent.cfg
@@ -334,7 +334,7 @@ PART
 				speed = 1.0 1.0
 				localRotation = -90, 0, 0
 			}
-		}		
+		}
 		engage
 		{
 			AUDIO
@@ -362,7 +362,7 @@ PART
 				pitch = 2.0
 				loop = false
 			}
-		}	
+		}
 	}
 }
 
@@ -583,7 +583,7 @@ PART
 					name = ASET_NUMINPUT_DISPLAY_DIFFUSE_PASSIVECOLOR
 					color= 0,40,0,255
 			}
-				
+
 			COLORDEFINITION
 			{
 					name = ASET_NUMINPUT_DISPLAY_EMISSIVE_ACTIVECOLOR
@@ -608,7 +608,7 @@ PART
 			}
 			COLORDEFINITION
 			{
-				name = ASET_NUMINPUT_DISPLAY_NEGATIVECOLOR 
+				name = ASET_NUMINPUT_DISPLAY_NEGATIVECOLOR
 				color= 0,0,0,255
 			}
 			COLORDEFINITION
@@ -680,7 +680,7 @@ PART
 			{
 				name = ASET_PLATETEXT_ZEROCOLOR
 				color= 255,255,255,255
-			}	
+			}
 		}
 	}
 }
@@ -792,7 +792,7 @@ PART
 //	Lunar Module ascent stage plume configuration.
 //	==================================================
 
-@PART[ROC-LEMAscent]:BEFORE[RealPlume]
+@PART[ROC-LEMAscent]:BEFORE[RealPlume]:NEEDS[!Waterfall]
 {
 	PLUME
 	{

--- a/GameData/ROCapsules/PartConfigs/LEM/Waterfall_Support_LEM.cfg
+++ b/GameData/ROCapsules/PartConfigs/LEM/Waterfall_Support_LEM.cfg
@@ -29,7 +29,7 @@
         }
         TEMPLATE
         {
-            templateName = waterfall-rcs-jet-1
+            templateName = rowaterfall-rcs-hypergolic-1
             overrideParentTransform = RCSthruster
             position = 0,0,0
             rotation = 0, 0, 180

--- a/GameData/ROCapsules/PartConfigs/LEM/Waterfall_Support_LEM.cfg
+++ b/GameData/ROCapsules/PartConfigs/LEM/Waterfall_Support_LEM.cfg
@@ -11,7 +11,10 @@
         glow = ro-hypergolic-az50
         glowStretch = 0.8
     }
+}
 
+@PART[ROC-LEMAscent]:AFTER[ROWaterfall]:NEEDS[Waterfall]
+{
     MODULE
     {
         name = ModuleWaterfallFX
@@ -36,9 +39,7 @@
             scale = 1.1, 1.1, 1.1
         }
     }
-}
-@PART[ROC-LEMAscent]:AFTER[ROWaterfall]:NEEDS[Waterfall]
-{
+
     @EFFECTS
     {
         control

--- a/GameData/ROCapsules/PartConfigs/LEM/Waterfall_Support_LEM.cfg
+++ b/GameData/ROCapsules/PartConfigs/LEM/Waterfall_Support_LEM.cfg
@@ -1,0 +1,76 @@
+@PART[ROC-LEMAscent]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        moduleID = #$/name$-lmae
+        template = waterfall-hypergolic-aerozine50-upper-1
+        audio = pressure-fed-1
+        position = 0,0,0.04
+        rotation = 0, 0, 0
+        scale = 0.51, 0.52, 0.52
+        glow = ro-hypergolic-az50
+        glowStretch = 0.8
+    }
+
+    MODULE
+    {
+        name = ModuleWaterfallFX
+        moduleID = #$/name$-rcs
+        CONTROLLER
+        {
+            name = atmosphereDepth
+            linkedTo = atmosphere_density
+        }
+        CONTROLLER
+        {
+            name = rcs
+            linkedTo = rcs
+            thrusterTransformName = RCSthruster
+        }
+        TEMPLATE
+        {
+            templateName = waterfall-rcs-jet-1
+            overrideParentTransform = RCSthruster
+            position = 0,0,0
+            rotation = 0, 0, 180
+            scale = 1.1, 1.1, 1.1
+        }
+    }
+}
+@PART[ROC-LEMAscent]:AFTER[ROWaterfall]:NEEDS[Waterfall]
+{
+    @EFFECTS
+    {
+        control
+        {
+            AUDIO_MULTI_POOL
+            {
+                channel = Ship
+                clip = sound_rocket_mini
+                transformName = RCSthruster
+                volume = 0.0 0.0
+                volume = 0.02 0.1
+                volume = 0.5 0.1
+                volume = 1.0 0.1
+                pitch = 0.0 0.75
+                pitch = 1.0 1.5
+                loop = true
+            }
+        }
+    }
+}
+
+
+@PART[ROC-LEM-LMDE]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = waterfall-hypergolic-aerozine50-upper-1
+        audio = pressure-fed-1
+        position = 0,0,0.03
+        rotation = 0, 0, 0
+        scale = 1.13, 1.13, 1.13
+        glow = ro-hypergolic-az50
+        glowStretch = 0.8
+    }
+}

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/Waterfall_Support_MercuryBDB.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/Waterfall_Support_MercuryBDB.cfg
@@ -2,7 +2,7 @@
 {
     ROWaterfall
     {
-        template = waterfall-rcs-jet-1
+        template = rowaterfall-rcs-cold-gas-1
         audio = rcs-jet-1
         transform = rcsTransform
         position = 0,0,0
@@ -15,7 +15,7 @@
 {
     ROWaterfall
     {
-        template = waterfall-rcs-jet-1
+        template = rowaterfall-rcs-cold-gas-1
         audio = rcs-jet-1
         transform = rcsTransform
         position = 0,0,0

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/Waterfall_Support_MercuryBDB.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/Waterfall_Support_MercuryBDB.cfg
@@ -1,0 +1,36 @@
+@PART[ROC-MercuryCMBDB]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = waterfall-rcs-jet-1
+        audio = rcs-jet-1
+        transform = rcsTransform
+        position = 0,0,0
+        rotation = 0, 0, 180
+        scale = 0.5, 0.5, 0.5
+    }
+}
+
+@PART[ROC-MercuryRCSBDB]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = waterfall-rcs-jet-1
+        audio = rcs-jet-1
+        transform = rcsTransform
+        position = 0,0,0
+        rotation = 0, 0, 180
+        scale = 0.4, 0.4, 0.4
+    }
+}
+
+@PART[ROC-MercuryCMBDB|ROC-MercuryRCSBDB]:AFTER[zROWaterfall_99_Finalize]:NEEDS[Waterfall]
+{
+    @EFFECTS
+    {
+        @running
+        {
+            |_ = rcs
+        }
+    }
+}

--- a/GameData/ROCapsules/PartConfigs/Orion/RP_Support_Orion.cfg
+++ b/GameData/ROCapsules/PartConfigs/Orion/RP_Support_Orion.cfg
@@ -2,7 +2,7 @@
 //	Orion RealPlume Support
 //	============================================================================
 
-@PART[ROC-OrionESM]:BEFORE[RealPlume]
+@PART[ROC-OrionESM]:BEFORE[RealPlume]:NEEDS[!Waterfall]
 {
 	PLUME_TEMPLATE
 	{

--- a/GameData/ROCapsules/PartConfigs/Orion/Waterfall_Support_Orion.cfg
+++ b/GameData/ROCapsules/PartConfigs/Orion/Waterfall_Support_Orion.cfg
@@ -2,7 +2,7 @@
 {
     ROWaterfall
     {
-        template = waterfall-rcs-jet-1
+        template = rowaterfall-rcs-hydrazine-1
         audio = rcs-jet-1
         transform = RCSthruster
         position = 0,-0.01,0
@@ -36,8 +36,7 @@
 {
     ROWaterfall
     {
-        template = waterfall-rcs-jet-1
-        audio = rcs-jet-1
+        autoConfig = rcs
         transform = RCSthruster
         position = 0,0,0
         rotation = 0, 0, 180

--- a/GameData/ROCapsules/PartConfigs/Orion/Waterfall_Support_Orion.cfg
+++ b/GameData/ROCapsules/PartConfigs/Orion/Waterfall_Support_Orion.cfg
@@ -1,0 +1,46 @@
+@PART[ROC-OrionCM]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = waterfall-rcs-jet-1
+        audio = rcs-jet-1
+        transform = RCSthruster
+        position = 0,-0.01,0
+        rotation = 0, 0, 180
+        scale = 1,1,1
+    }
+}
+
+@PART[ROC-OrionESM]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = waterfall-hypergolic-white-upper-1
+        transform = newThrustTransform
+        audio = pressure-fed-1
+        position = 0,0,-0.085
+        rotation = 0, 0, 0
+        scale = 0.24, 0.24, 0.24
+
+        ExtraTemplate
+        {
+            template = rowaterfall-glow-hypergolic-white
+            position = 0,0,-0.085
+            rotation = 0, 0, 0
+            scale = 0.23, 0.23, 0.7
+        }
+    }
+}
+
+@PART[ROC-OrionRCS]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        template = waterfall-rcs-jet-1
+        audio = rcs-jet-1
+        transform = RCSthruster
+        position = 0,0,0
+        rotation = 0, 0, 180
+        scale = 0.7, 1, 0.7
+    }
+}

--- a/GameData/ROCapsules/PartConfigs/Vostok/VostokService.cfg
+++ b/GameData/ROCapsules/PartConfigs/Vostok/VostokService.cfg
@@ -42,7 +42,7 @@ PART
 	//	============================================================================
 	//	Thermo, Durability
 	//	============================================================================
-	
+
 	mass = 1.924
 	dragModelType = default
 	maximum_drag = 0.2
@@ -234,7 +234,7 @@ PART
 	//  ============================================================================
 	//	Comms
 	//  ============================================================================
-	
+
 	MODULE:NEEDS[!RemoteTech]
 	{
 		name = ModuleDataTransmitter
@@ -245,12 +245,12 @@ PART
 		antennaPower = 400
 		packetResourceCost = 0.004
 	}
-	
+
 	MODULE:NEEDS[RemoteTech]
 	{
 		name = ModuleSPUPassive
 	}
-	
+
 	MODULE:NEEDS[RemoteTech]
 	{
 		name = ModuleRTAntennaPassive
@@ -283,7 +283,7 @@ PART
 //	Configure RealPlume
 //	================================================================================
 
-@PART[ROC-VostokService]:BEFORE[RealPlume]
+@PART[ROC-VostokService]:BEFORE[RealPlume]:NEEDS[!Waterfall]
 {
 	PLUME
 	{

--- a/GameData/ROCapsules/PartConfigs/Vostok/Waterfall_Support_Vostok.cfg
+++ b/GameData/ROCapsules/PartConfigs/Vostok/Waterfall_Support_Vostok.cfg
@@ -28,7 +28,7 @@
         }
         TEMPLATE
         {
-            templateName = waterfall-rcs-jet-1
+            templateName = rowaterfall-rcs-hypergolic-1
             overrideParentTransform = RCSthruster
             position = 0,-0.007,0
             rotation = 0, 0, 180

--- a/GameData/ROCapsules/PartConfigs/Vostok/Waterfall_Support_Vostok.cfg
+++ b/GameData/ROCapsules/PartConfigs/Vostok/Waterfall_Support_Vostok.cfg
@@ -10,7 +10,10 @@
         scale = 0.2, 0.2, 0.3
         glow = ro-hypergolic-white
     }
+}
 
+@PART[ROC-VostokService]:AFTER[ROWaterfall]:NEEDS[Waterfall]
+{
     MODULE
     {
         name = ModuleWaterfallFX
@@ -35,9 +38,7 @@
             scale = 0.8, 0.8, 0.8
         }
     }
-}
-@PART[ROC-VostokService]:AFTER[ROWaterfall]:NEEDS[Waterfall]
-{
+
     @EFFECTS
     {
         running1

--- a/GameData/ROCapsules/PartConfigs/Vostok/Waterfall_Support_Vostok.cfg
+++ b/GameData/ROCapsules/PartConfigs/Vostok/Waterfall_Support_Vostok.cfg
@@ -1,0 +1,60 @@
+@PART[ROC-VostokService]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+{
+    ROWaterfall
+    {
+        moduleID = #$/name$-s5.4
+        template = waterfall-hypergolic-white-upper-1
+        audio = pressure-fed-1
+        position = 0,0,0
+        rotation = 0, 0, 0
+        scale = 0.2, 0.2, 0.3
+        glow = ro-hypergolic-white
+    }
+
+    MODULE
+    {
+        name = ModuleWaterfallFX
+        moduleID = #$/name$-rcs
+        CONTROLLER
+        {
+            name = atmosphereDepth
+            linkedTo = atmosphere_density
+        }
+        CONTROLLER
+        {
+            name = rcs
+            linkedTo = rcs
+            thrusterTransformName = RCSthruster
+        }
+        TEMPLATE
+        {
+            templateName = waterfall-rcs-jet-1
+            overrideParentTransform = RCSthruster
+            position = 0,-0.007,0
+            rotation = 0, 0, 180
+            scale = 0.8, 0.8, 0.8
+        }
+    }
+}
+@PART[ROC-VostokService]:AFTER[ROWaterfall]:NEEDS[Waterfall]
+{
+    @EFFECTS
+    {
+        running1
+        {
+            AUDIO_MULTI_POOL
+            {
+                channel = Ship
+                clip = sound_rocket_mini
+                transformName = RCSthruster
+                volume = 0.0 0.0
+                volume = 0.02 0.1
+                volume = 0.5 0.1
+                volume = 1.0 0.1
+                pitch = 0.0 0.75
+                pitch = 1.0 1.5
+                loop = true
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds optional Waterfall support for all ROCapsules parts with RCS thrusters and/or engines. Specifically, configs and RealPlume deconflict patches have been added for the following parts:

* Apollo
  * Command Module
  * RCS block
* Apollo LEM
  * Ascent Module (LMAE + RCS)
  * LMDE
* Apollo (Eyes Turned Skyward)
  * Block III+ Command Module
  * Block III Engine
  * Block V Engine
* CST-100 Starliner
  * Command Module
  * Service Module
  * RS-88
* Dynasoar
  * Aft Bay (RCS only)
  * Fuselage
  * Wings
* Gemini (BDB models)
  * Equipment Module
  * Orbital Attitude and Maneuvering System
  * Reentry Control System
  * Retro Module
* Mercury
  * Command Module
  * Landing and Control Module
* Orion
  * Command Module
  * European Service Module
  * RCS block
* Vostok
  * Support Module

Some of these parts have rather unsightly artifacts due to model problems, most notably the LEM Ascent Module and the Orion capsule. Unfortunately, there is not much for me to do about that.

**Requires https://github.com/KSP-RO/RealismOverhaul/pull/2430.**

cc @vevladdd