### PR TITLE
Fix GeminiOAMS RCS alignment

### DIFF
--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiOAMS.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiOAMS.cfg
@@ -94,6 +94,7 @@ PART
 		enableRoll = false
 		enablePitch = false
 		enableYaw = false
+		useZaxis = True
 		PROPELLANT
 		{
 			name = MMH


### PR DESCRIPTION
Engine models reused as RCS need useZaxis = True in moduleRCSFX
Fixes #87 