### PR TITLE
Fix D2 docking port AcquireRange to make undocking possible

### DIFF
--- a/GameData/ROCapsules/PartConfigs/Apollo D2/D2DockDrogue.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo D2/D2DockDrogue.cfg
@@ -72,7 +72,7 @@ PART
 		acquireForce = 0.5 // 2
 		acquireMinFwdDot = 0.8 // 0.7
 		acquireminRollDot = -3.40282347E+38
-		acquireRange = 0.5 // 0.5
+		acquireRange = 0.25 // 0.5
 		acquireTorque = 0.5 // 2.0
 		captureMaxRvel = 0.1 // 0.3
 		captureMinFwdDot = 0.996

--- a/GameData/ROCapsules/PartConfigs/Apollo D2/D2DockProbe.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo D2/D2DockProbe.cfg
@@ -73,7 +73,7 @@ PART
 		acquireForce = 0.5 // 2
 		acquireMinFwdDot = 0.8 // 0.7
 		acquireminRollDot = -3.40282347E+38
-		acquireRange = 0.5 // 0.5
+		acquireRange = 0.25 // 0.5
 		acquireTorque = 0.5 // 2.0
 		captureMaxRvel = 0.1 // 0.3
 		captureMinFwdDot = 0.996


### PR DESCRIPTION
At 0.5, it is almost impossible to undock things with these ports at the default acquire force. 0.25 fixes that (and brings it in line with other docking ports)