### PR TITLE
Add pressure-fed tag to OAMS

### DIFF
--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiOAMS.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiOAMS.cfg
@@ -228,6 +228,9 @@ PART
 			name = OAMS
 			minThrust = 0.4448222 // 100 lb
 			maxThrust = 0.4448222 // 100 lb
+			ullage = False
+			pressureFed = True
+			ignitions = 0
 
 			PROPELLANT
 			{


### PR DESCRIPTION
Add pressure fed tag to the Gemini OAMS thrusters