### PR TITLE
Add 4kL fuel tank to D-2 1-engine Skirt Section

### DIFF
--- a/GameData/ROCapsules/PartConfigs/Apollo D2/D2Skirt2.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo D2/D2Skirt2.cfg
@@ -138,4 +138,12 @@ PART
 			key = 1 100
 		}
 	}
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		type = ServiceModule
+		volume = 4000.0
+		basemass = -1
+	}
 }


### PR DESCRIPTION
Visually the 1-engine and 4-engine skirts have spherical fuel tanks of the same size but the 1-engine skirt was lacking the fuel tank config.

I copied the MFT config directly from the 4-engine skirt. I don't know if this needs any additional changes for cost or mass balancing.