### PR TITLE
Fix :FOR[RealismOverhaul] in ROCapsules

### DIFF
--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiCM.cfg
@@ -381,7 +381,7 @@ PART
 //	Final Pass to Make Sure TAC does not add extra resources
 //	================================================================================
 
-@PART[ROC-GeminiCMBDB]:FOR[zzzRealismOverhaul]
+@PART[ROC-GeminiCMBDB]:BEFORE[zzzRealismOverhaul]
 {
 	!RESOURCE:HAS[~name[Ablator],~name[CharredAblator]],*{}
 }

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiEquipmentSection.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiEquipmentSection.cfg
@@ -378,7 +378,7 @@ PART
 //	Final Pass to Make Sure TAC does not add extra resources
 //	================================================================================
 
-@PART[ROC-GeminiEquipmentSectionBDB]:FOR[zzzRealismOverhaul]
+@PART[ROC-GeminiEquipmentSectionBDB]:BEFORE[zzzRealismOverhaul]
 {
 	!RESOURCE:HAS[~name[Ablator],~name[CharredAblator]],*{}
 }

--- a/GameData/ROCapsules/PartConfigs/LEM/LEMAscent.cfg
+++ b/GameData/ROCapsules/PartConfigs/LEM/LEMAscent.cfg
@@ -794,7 +794,7 @@ PART
 //	And also override the mass set by RO engine configs
 //	================================================================================
 
-@PART[ROC-LEMAscent]:FOR[zzzRealismOverhaul]
+@PART[ROC-LEMAscent]:BEFORE[zzzRealismOverhaul]
 {
 	!RESOURCE,*{}
 	@mass = 2.2

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryCM.cfg
@@ -527,7 +527,7 @@ PART
 //	Final Pass to Make Sure TAC does not add extra resources
 //	================================================================================
 
-@PART[ROC-MercuryCM]:FOR[zzzRealismOverhaul]
+@PART[ROC-MercuryCM]:BEFORE[zzzRealismOverhaul]
 {
 	!RESOURCE:HAS[~name[Ablator],~name[CharredAblator]],*{}
 }

--- a/GameData/ROCapsules/PartConfigs/Vostok/VoskhodCapsule.cfg
+++ b/GameData/ROCapsules/PartConfigs/Vostok/VoskhodCapsule.cfg
@@ -191,7 +191,7 @@ PART
 //	TAC Life Support compatibility.
 //	==================================================
 
-@PART[ROC-VoskhodCapsule]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
+@PART[ROC-VoskhodCapsule]:BEFORE[RealismOverhaul]:NEEDS[TacLifeSupport]
 {
 	@MODULE[ModuleFuelTanks]
 	{

--- a/GameData/ROCapsules/PartConfigs/Vostok/VostokCapsule.cfg
+++ b/GameData/ROCapsules/PartConfigs/Vostok/VostokCapsule.cfg
@@ -189,7 +189,7 @@ PART
 //	TAC Life Support compatibility.
 //	==================================================
 
-@PART[ROC-VostokCapsule]:FOR[RealismOverhaul]:NEEDS[TacLifeSupport]
+@PART[ROC-VostokCapsule]:BEFORE[RealismOverhaul]:NEEDS[TacLifeSupport]
 {
 	@MODULE[ModuleFuelTanks]
 	{


### PR DESCRIPTION
Hi KSP-RO team,

This is like KSP-RO/RP-0#1652 but for ROCapsules. All occurrences of `:FOR[RealismOverhaul]` and `:FOR[zzzRealismOverhaul]` are converted to use `:BEFORE`.
