### PR TITLE
Update capsule thermals

### DIFF
--- a/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloCMBlockIII+.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloCMBlockIII+.cfg
@@ -67,13 +67,23 @@ PART
 	//	Thermo, Durability
 	//	============================================================================
 
+	//Thermal Stuff
+	//Skin made of Stainless steel, coated with ablative layer of varying thickness, and Klapton insulation
+	//Peak temp on HS: ~3000 K
+	//Peak temp on Walls: ~2000 K
+	//Peak temp on forward surfaces: ~1100 K
+	maxTemp = 973.15
+	skinMaxTemp = 3000					//Ablative coating wrapped around sides of Apollo to account for extreme flux.
+	emissiveConstant = 0.4				//Metallicized Klapton coating.
+	heatConductivity = 1.0				//All conductivity. Leave this alone for now
+	thermalMassModifier = 1.0			//Thermal mass. Leave this alone for now
+	skinInternalConductionMult = 0.005	//Skin-to-int conductivity. Skin coated in ablator, and isolated from Aluminum hull with very thick insulation layer.
+	skinMassPerArea = 7.9				//1 mm thick stainless, 7.9 kg/m^2?
+	skinThermalMassModifier = 1.0		//Skin thermal mass. Leave this alone for now
+	skinSkinConductionMult = 0.05		//Skin well insulated and connected with slip-joints. Probably not much conduction.
+	
 	mass = 3.234
 	crashTolerance = 8
-	maxTemp = 973.15
-	skinMaxTemp = 3600
-	emissiveConstant = 0.54 // stainless steel
-	thermalMassModifier = 1.0
-	skinMassPerArea = 7.9 //1 mm thick stainless
 	buoyancy = 1.1
 	breakingForce = 250
 	breakingTorque = 250
@@ -117,19 +127,21 @@ PART
 	//	============================================================================
 	//	Modules and Resources
 	//	============================================================================
-
+	
+	//Same structure as main HS, use lunar HS settings
+	//This actually survives LEO reentry on it's own. Probably not ideal
 	MODULE
 	{
 		name:NEEDS[!DeadlyReentry] = ModuleAblator
 		name:NEEDS[DeadlyReentry] = ModuleHeatShield
 		ablativeResource = Ablator
 		outputResource = CharredAblator
-		outputMult = 0.75
+		outputMult = 0.8
 		lossExp = -25000
-		lossConst = 15
-		pyrolysisLossFactor = 1458330
+		lossConst = 150
+		pyrolysisLossFactor = 145833
 		ablationTempThresh = 1250
-		reentryConductivity = 0.001
+		reentryConductivity = 0.0025
 		depletedMaxTemp:NEEDS[DeadlyReentry] = 1200
 		infoTemp = 3000
 	}
@@ -142,10 +154,10 @@ PART
 	RESOURCE
 	{
 		name = CharredAblator
-		maxAmount = 7.5
+		maxAmount = 8
 		amount = 0
 	}
-  
+
 	MODULE
 	{
 		name = ModuleCommand
@@ -166,7 +178,7 @@ PART
 	MODULE
 	{
 		name = AdjustableCoMShifter
-		DescentModeCoM = 0, 0, -0.17
+		DescentModeCoM = 0, 0, 0.17	//Apollo should reenter "upside-down" to protect crew hatch
 	}
 
 	MODULE
@@ -619,4 +631,12 @@ PART
 		referenceGain = 3.0		//Guess based on Block II
 		RFBand = S		//Default to S-band
 	}
+}
+
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-ApolloCMBlockIII]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 3000		//Keep this lower to "discourage" attempting reentry without HS
 }

--- a/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloCMBlockIII+.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloCMBlockIII+.cfg
@@ -636,7 +636,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-ApolloCMBlockIII]:FOR[RealismOverhaul]
+@PART[ROC-ApolloCMBlockIII]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 3000		//Keep this lower to "discourage" attempting reentry without HS
 }

--- a/GameData/ROCapsules/PartConfigs/Apollo/ApolloCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo/ApolloCM.cfg
@@ -101,8 +101,7 @@ PART
 	//This actually survives LEO reentry on it's own. Probably not ideal
 	MODULE
 	{
-		name:NEEDS[!DeadlyReentry] = ModuleAblator
-		name:NEEDS[DeadlyReentry] = ModuleHeatShield
+		name = ModuleAblator
 		ablativeResource = Ablator
 		outputResource = CharredAblator
 		outputMult = 0.8
@@ -111,7 +110,6 @@ PART
 		pyrolysisLossFactor = 145833
 		ablationTempThresh = 1250
 		reentryConductivity = 0.0025
-		depletedMaxTemp:NEEDS[DeadlyReentry] = 1200
 		infoTemp = 3000
 	}
 	RESOURCE

--- a/GameData/ROCapsules/PartConfigs/Apollo/ApolloCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo/ApolloCM.cfg
@@ -70,13 +70,23 @@ PART
 	//	============================================================================
 	//	Thermo, Durability
 	//	============================================================================
-		
-	crashTolerance = 8
+	
+	//Thermal Stuff
+	//Skin made of Stainless steel, coated with ablative layer of varying thickness, and Klapton insulation
+	//Peak temp on HS: ~3000 K
+	//Peak temp on Walls: ~2000 K
+	//Peak temp on forward surfaces: ~1100 K
 	maxTemp = 973.15
-	skinMaxTemp = 3600
-	emissiveConstant = 0.54 // stainless steel
-	thermalMassModifier = 1.0
-	skinMassPerArea = 7.9 //1 mm thick stainless
+	skinMaxTemp = 3000					//Ablative coating wrapped around sides of Apollo to account for extreme flux.
+	emissiveConstant = 0.4				//Metallicized Klapton coating.
+	heatConductivity = 1.0				//All conductivity. Leave this alone for now
+	thermalMassModifier = 1.0			//Thermal mass. Leave this alone for now
+	skinInternalConductionMult = 0.005	//Skin-to-int conductivity. Skin coated in ablator, and isolated from Aluminum hull with very thick insulation layer.
+	skinMassPerArea = 7.9				//1 mm thick stainless, 7.9 kg/m^2?
+	skinThermalMassModifier = 1.0		//Skin thermal mass. Leave this alone for now
+	skinSkinConductionMult = 0.05		//Skin well insulated and connected with slip-joints. Probably not much conduction.
+	
+	crashTolerance = 8
 	buoyancy = 1.1
 	breakingForce = 250
 	breakingTorque = 250
@@ -86,18 +96,21 @@ PART
 	//	============================================================================
 	//	Modules and Resources
 	//	============================================================================
+	
+	//Same structure as main HS, use lunar HS settings
+	//This actually survives LEO reentry on it's own. Probably not ideal
 	MODULE
 	{
 		name:NEEDS[!DeadlyReentry] = ModuleAblator
 		name:NEEDS[DeadlyReentry] = ModuleHeatShield
 		ablativeResource = Ablator
 		outputResource = CharredAblator
-		outputMult = 0.75
+		outputMult = 0.8
 		lossExp = -25000
-		lossConst = 15
-		pyrolysisLossFactor = 1458330
+		lossConst = 150
+		pyrolysisLossFactor = 145833
 		ablationTempThresh = 1250
-		reentryConductivity = 0.001
+		reentryConductivity = 0.0025
 		depletedMaxTemp:NEEDS[DeadlyReentry] = 1200
 		infoTemp = 3000
 	}
@@ -110,7 +123,7 @@ PART
 	RESOURCE
 	{
 		name = CharredAblator
-		maxAmount = 7.5
+		maxAmount = 8
 		amount = 0
 	}
 	
@@ -134,7 +147,7 @@ PART
 	MODULE
 	{
 		name = AdjustableCoMShifter
-		DescentModeCoM = 0, 0, -0.17
+		DescentModeCoM = 0, 0, 0.17	//Apollo should reenter "upside-down" to protect crew hatch
 	}
 
 	MODULE
@@ -606,4 +619,12 @@ PART
 @PART[ROC-ApolloCM]:LAST[ROCapsules]
 {
 	!RESOURCE:HAS[~name[Ablator],~name[CharredAblator]],*{}
+}
+
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-ApolloCM]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 3000		//Keep this lower to "discourage" attempting reentry without HS
 }

--- a/GameData/ROCapsules/PartConfigs/Apollo/ApolloCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo/ApolloCM.cfg
@@ -624,7 +624,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-ApolloCM]:FOR[RealismOverhaul]
+@PART[ROC-ApolloCM]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 3000		//Keep this lower to "discourage" attempting reentry without HS
 }

--- a/GameData/ROCapsules/PartConfigs/Apollo/ApolloForwardHS.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo/ApolloForwardHS.cfg
@@ -54,10 +54,23 @@ PART
 	//	============================================================================
 	//	Thermo, Durability
 	//	============================================================================
-		
-	crashTolerance = 10
+	
+	//Thermal Stuff
+	//Skin made of Stainless steel, coated with ablative layer of varying thickness, and Klapton insulation
+	//Peak temp on HS: ~3000 K
+	//Peak temp on Walls: ~2000 K
+	//Peak temp on forward surfaces: ~1100 K
 	maxTemp = 973.15
-	skinMaxTemp = 1073.15
+	skinMaxTemp = 3000					//Ablative coating wrapped around sides of Apollo to account for extreme flux.
+	emissiveConstant = 0.4				//Metallicized Klapton coating.
+	heatConductivity = 1.0				//All conductivity. Leave this alone for now
+	thermalMassModifier = 1.0			//Thermal mass. Leave this alone for now
+	skinInternalConductionMult = 0.005	//Skin-to-int conductivity. Skin coated in ablator, and isolated from Aluminum hull with very thick insulation layer.
+	skinMassPerArea = 7.9				//1 mm thick stainless, 7.9 kg/m^2?
+	skinThermalMassModifier = 1.0		//Skin thermal mass. Leave this alone for now
+	skinSkinConductionMult = 0.05		//Skin well insulated and connected with slip-joints. Probably not much conduction.
+	
+	crashTolerance = 10
 	breakingForce = 250
 	breakingTorque = 250
 	bodyLiftMultiplier = 0
@@ -117,4 +130,12 @@ PART
 	
 	fx_gasBurst_white = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, decouple
 	sound_decoupler_fire = decouple
+}
+
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-ApolloForwardHS]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 3000
 }

--- a/GameData/ROCapsules/PartConfigs/Apollo/ApolloForwardHS.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo/ApolloForwardHS.cfg
@@ -135,7 +135,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-ApolloForwardHS]:FOR[RealismOverhaul]
+@PART[ROC-ApolloForwardHS]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 3000
 }

--- a/GameData/ROCapsules/PartConfigs/CST/CSTCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/CST/CSTCM.cfg
@@ -66,11 +66,18 @@ PART
 	minimum_drag = 0.15
 	angularDrag = 2
 	crashTolerance = 12
-	maxTemp = 973.15
-	skinMaxTemp = 2673.15
-	emissiveConstant = 0.6
-	thermalMassModifier = 1.0
-	skinMassPerArea = 4
+	
+	//Thermal Stuff
+	//Skin made of Titanium, coated with shuttle legacy BRI-18 tiles and AFRSI blankets
+	maxTemp = 773
+	skinMaxTemp = 1533					//Approximate maximum temp of shuttle HSRI tiles
+	emissiveConstant = 0.85				//Metallicized Nomex?
+	heatConductivity = 1.0				//All conductivity. Leave this alone for now
+	thermalMassModifier = 1.0			//Thermal mass. Leave this alone for now
+	skinInternalConductionMult = 0.005	//Skin-to-int conductivity. Skin coated in shuttle-grade tiles and blankets, very well insulated
+	skinMassPerArea = 15.99				//25 mm BRI-18 tiles? Assuming at shuttle density of 9 lbs/ft^3, 15.99 kg/m^2
+	skinThermalMassModifier = 1.0		//Skin thermal mass. Leave this alone for now
+	skinSkinConductionMult = 0.005		//Skin extremely well insulated and isolated. Probably not much conduction.
 
 	//	============================================================================
 	//	Animations and Textures
@@ -399,4 +406,12 @@ PART
 			Ratio = 0.01
 		}
 	}
+}
+
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-CSTCM]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 1533
 }

--- a/GameData/ROCapsules/PartConfigs/CST/CSTCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/CST/CSTCM.cfg
@@ -411,7 +411,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-CSTCM]:FOR[RealismOverhaul]
+@PART[ROC-CSTCM]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 1533
 }

--- a/GameData/ROCapsules/PartConfigs/CST/CSTParachute.cfg
+++ b/GameData/ROCapsules/PartConfigs/CST/CSTParachute.cfg
@@ -184,7 +184,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-CSTParachute]:FOR[RealismOverhaul]
+@PART[ROC-CSTParachute]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 1533
 }

--- a/GameData/ROCapsules/PartConfigs/CST/CSTParachute.cfg
+++ b/GameData/ROCapsules/PartConfigs/CST/CSTParachute.cfg
@@ -48,9 +48,6 @@ PART
 	dragModelType = default
 	angularDrag = .1
 	crashTolerance = 10
-	emissiveConstant = 0.6
-	thermalMassModifier = 1.0
-	skinMassPerArea = 4
 	breakingForce = 100
 	breakingTorque = 50
 	bodyLiftMultiplier = 0
@@ -59,6 +56,18 @@ PART
 	stageOffset = 1
 	childStageOffset = 1
 	buoyancyUseCubeNamed = PACKED
+	
+	//Thermal Stuff
+	//Skin made of Titanium, coated with shuttle legacy BRI-18 tiles and AFRSI blankets
+	maxTemp = 773
+	skinMaxTemp = 1533					//Approximate maximum temp of shuttle HSRI tiles
+	emissiveConstant = 0.85				//Metallicized Nomex?
+	heatConductivity = 1.0				//All conductivity. Leave this alone for now
+	thermalMassModifier = 1.0			//Thermal mass. Leave this alone for now
+	skinInternalConductionMult = 0.005	//Skin-to-int conductivity. Skin coated in shuttle-grade tiles and blankets, very well insulated
+	skinMassPerArea = 15.99				//25 mm BRI-18 tiles? Assuming at shuttle density of 9 lbs/ft^3, 15.99 kg/m^2
+	skinThermalMassModifier = 1.0		//Skin thermal mass. Leave this alone for now
+	skinSkinConductionMult = 0.005		//Skin extremely well insulated and isolated. Probably not much conduction.
 
 	//	============================================================================
 	//	Animations and Textures
@@ -170,4 +179,12 @@ PART
 	{
 		%forceUseMeshes = True
 	}
+}
+
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-CSTParachute]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 1533
 }

--- a/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaAftBayMoroz.cfg
+++ b/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaAftBayMoroz.cfg
@@ -175,7 +175,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-DynaAdapterBigMoroz]:FOR[RealismOverhaul]
+@PART[ROC-DynaAdapterBigMoroz]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 1144
 }

--- a/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaAftBayMoroz.cfg
+++ b/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaAftBayMoroz.cfg
@@ -171,3 +171,11 @@ PART
 		}
 	}
 }
+
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-DynaAdapterBigMoroz]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 1144
+}

--- a/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaBayMoroz.cfg
+++ b/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaBayMoroz.cfg
@@ -110,7 +110,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-DynaBayMoroz]:FOR[RealismOverhaul]
+@PART[ROC-DynaBayMoroz]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 2000
 }

--- a/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaBayMoroz.cfg
+++ b/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaBayMoroz.cfg
@@ -106,3 +106,11 @@ PART
 		}
 	}
 }
+
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-DynaBayMoroz]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 2000
+}

--- a/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaButtMoroz.cfg
+++ b/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaButtMoroz.cfg
@@ -265,7 +265,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-DynaButtMoroz]:FOR[RealismOverhaul]
+@PART[ROC-DynaButtMoroz]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 2000
 }

--- a/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaButtMoroz.cfg
+++ b/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaButtMoroz.cfg
@@ -261,3 +261,11 @@ PART
 		}
 	}
 }
+
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-DynaButtMoroz]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 2000
+}

--- a/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaCabinMoroz.cfg
+++ b/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaCabinMoroz.cfg
@@ -158,7 +158,7 @@ PART
 //	================================================================================
 //	TAC Life Support Compatibility
 //	================================================================================
-@PART[ROC-DynaCockpitMoroz]:FOR[ROCapsules]:NEEDS[TacLifeSupport]
+@PART[ROC-DynaCabinMoroz]:FOR[ROCapsules]:NEEDS[TacLifeSupport]
 {
 
 	//Scrubber
@@ -234,4 +234,12 @@ PART
 			maxAmount = 81.31
 		}
 	}
+}
+
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-DynaCabinMoroz]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 2000
 }

--- a/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaCabinMoroz.cfg
+++ b/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaCabinMoroz.cfg
@@ -239,7 +239,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-DynaCabinMoroz]:FOR[RealismOverhaul]
+@PART[ROC-DynaCabinMoroz]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 2000
 }

--- a/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaCockpitMoroz.cfg
+++ b/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaCockpitMoroz.cfg
@@ -375,7 +375,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-DynaCockpitMoroz]:FOR[RealismOverhaul]
+@PART[ROC-DynaCockpitMoroz]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 2000
 }

--- a/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaCockpitMoroz.cfg
+++ b/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaCockpitMoroz.cfg
@@ -371,3 +371,11 @@ PART
 		}
 	}
 }
+
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-DynaCockpitMoroz]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 2000
+}

--- a/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaElevonMoroz.cfg
+++ b/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaElevonMoroz.cfg
@@ -110,7 +110,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-DynaElevonMoroz]:FOR[RealismOverhaul]
+@PART[ROC-DynaElevonMoroz]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 2000
 }

--- a/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaElevonMoroz.cfg
+++ b/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaElevonMoroz.cfg
@@ -103,6 +103,14 @@ PART
 			{
 				mainTextureURL = ROCapsules/Assets/IronCretin/X20_wing_white
 			}
-		}	
-	}	
+		}
+	}
+}
+
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-DynaElevonMoroz]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 2000
 }

--- a/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaRudderMoroz.cfg
+++ b/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaRudderMoroz.cfg
@@ -106,7 +106,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-DynaRudderMoroz]:FOR[RealismOverhaul]
+@PART[ROC-DynaRudderMoroz]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 2000
 }

--- a/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaRudderMoroz.cfg
+++ b/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaRudderMoroz.cfg
@@ -99,6 +99,14 @@ PART
 			{
 				mainTextureURL = ROCapsules/Assets/IronCretin/X20_wing_white
 			}
-		}	
-	}	
+		}
+	}
+}
+
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-DynaRudderMoroz]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 2000
 }

--- a/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaShieldMoroz.cfg
+++ b/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaShieldMoroz.cfg
@@ -53,7 +53,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-DynaShieldMoroz]:FOR[RealismOverhaul]
+@PART[ROC-DynaShieldMoroz]:AFTER[RealismOverhaul]
 {
 	@maxTemp = 1144		//Just solid Rene 41?
 	@skinMaxTemp = 1144

--- a/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaShieldMoroz.cfg
+++ b/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaShieldMoroz.cfg
@@ -49,3 +49,12 @@ PART
 		explosiveNodeID = top
 	}
 }
+
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-DynaShieldMoroz]:FOR[RealismOverhaul]
+{
+	@maxTemp = 1144		//Just solid Rene 41?
+	@skinMaxTemp = 1144
+}

--- a/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaWingMoroz.cfg
+++ b/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaWingMoroz.cfg
@@ -167,3 +167,12 @@ PART
 		}
 	}
 }
+
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-DynaWingMoroz]:FOR[RealismOverhaul]
+{
+	@maxTemp = 1144
+	@skinMaxTemp = 2000
+}

--- a/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaWingMoroz.cfg
+++ b/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaWingMoroz.cfg
@@ -171,7 +171,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-DynaWingMoroz]:FOR[RealismOverhaul]
+@PART[ROC-DynaWingMoroz]:AFTER[RealismOverhaul]
 {
 	@maxTemp = 1144
 	@skinMaxTemp = 2000

--- a/GameData/ROCapsules/PartConfigs/DynasoarMoroz/Waterfall_Support_Dynasoar_Moroz.cfg
+++ b/GameData/ROCapsules/PartConfigs/DynasoarMoroz/Waterfall_Support_Dynasoar_Moroz.cfg
@@ -1,4 +1,4 @@
-@PART[ROC-DynaCockpitMoroz|ROC-DynaWingMoroz|ROC-DynaButtMoroz]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+@PART[ROC-DynaCockpitMoroz|ROC-DynaCockpitAltMoroz|ROC-DynaWingMoroz|ROC-DynaButtMoroz]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
 {
     ROWaterfall
     {

--- a/GameData/ROCapsules/PartConfigs/Gemini/GeminiFlightPack.cfg
+++ b/GameData/ROCapsules/PartConfigs/Gemini/GeminiFlightPack.cfg
@@ -48,10 +48,24 @@ PART
 	crashTolerance = 15
 	breakingForce = 25
 	breakingTorque = 25
-	maxTemp = 3200
 
 	CoMOffset = 0.0, -0.35, 0.0
 
+	
+	//Thermal Stuff
+	//Assuming same as Dynasoar
+	//Structure and skin made of Rene 41 (max temp 1144)
+	//Belly coated with Molybdenum (max temp ~2000)
+	//Nose made of graphite
+	//Very high emissivity paint applied to maximize radiation
+	heatConductivity = 0.25		//all conductivity
+	skinInternalConductionMult = 0.005	//skin-to-int conductivity
+	skinMassPerArea = 8.25 //1 mm Rene 41
+	thermalMassModifier = 2.0
+	emissiveConstant = 0.95		//matte black
+
+	maxTemp = 773	//delicate, lower int temp
+	skinMaxTemp = 2000
 
 	stageOffset = 1
 	childStageOffset = 1
@@ -125,4 +139,12 @@ PART
 		rimColor = 0.6242, 0.6445, 0.6914, 1.0
 		ReflectionColor = 0.6442, 0.6445, 0.64, 1.0
 	}
+}
+
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-GeminiFlightPack]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 2000
 }

--- a/GameData/ROCapsules/PartConfigs/Gemini/GeminiFlightPack.cfg
+++ b/GameData/ROCapsules/PartConfigs/Gemini/GeminiFlightPack.cfg
@@ -144,7 +144,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-GeminiFlightPack]:FOR[RealismOverhaul]
+@PART[ROC-GeminiFlightPack]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 2000
 }

--- a/GameData/ROCapsules/PartConfigs/Gemini/GeminiFlightPackContSurf.cfg
+++ b/GameData/ROCapsules/PartConfigs/Gemini/GeminiFlightPackContSurf.cfg
@@ -38,15 +38,27 @@ PART
 	// --- standard part parameters ---
 	mass = 0.02
 	thermalMassModifier = 4.0 // the dang things are light, so 3200 kJ/tonne-K
-	heatConductivity = 0.06 // half default
-	emissiveConstant = 0.95
 	dragModelType = none
 	maximum_drag = 0.02
 	minimum_drag = 0.02
 	angularDrag = 0.75
 	crashTolerance = 10
-	maxTemp = 2600
 	explosionPotential = 0.1
+
+	//Thermal Stuff
+	//Assuming same as Dynasoar
+	//Structure and skin made of Rene 41 (max temp 1144)
+	//Belly coated with Molybdenum (max temp ~2000)
+	//Nose made of graphite
+	//Very high emissivity paint applied to maximize radiation
+	heatConductivity = 0.25		//all conductivity
+	skinInternalConductionMult = 0.005	//skin-to-int conductivity
+	skinMassPerArea = 8.25 //1 mm Rene 41
+	thermalMassModifier = 2.0
+	emissiveConstant = 0.95		//matte black
+
+	maxTemp = 773	//delicate, lower int temp
+	skinMaxTemp = 2000
 
 	// --- winglet parameters ---
 
@@ -112,5 +124,12 @@ PART
 		rimColor = 0.6242, 0.6445, 0.6914, 1.0
 		ReflectionColor = 0.6442, 0.6445, 0.64, 1.0
 	}
+}
 
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-GeminiFlightPackContSurf]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 2000
 }

--- a/GameData/ROCapsules/PartConfigs/Gemini/GeminiFlightPackContSurf.cfg
+++ b/GameData/ROCapsules/PartConfigs/Gemini/GeminiFlightPackContSurf.cfg
@@ -129,7 +129,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-GeminiFlightPackContSurf]:FOR[RealismOverhaul]
+@PART[ROC-GeminiFlightPackContSurf]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 2000
 }

--- a/GameData/ROCapsules/PartConfigs/Gemini/GeminiWing.cfg
+++ b/GameData/ROCapsules/PartConfigs/Gemini/GeminiWing.cfg
@@ -36,9 +36,6 @@ PART
 	// definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 	node_stack_top = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
 	mass = 0.5
-	thermalMassModifier = 2.25
-	heatConductivity = 0.1
-	emissiveConstant = 0.95
 	dragModelType = none
 	maximum_drag = 0.01
 	minimum_drag = 0.01
@@ -46,8 +43,22 @@ PART
 	crashTolerance = 8
 	breakingForce = 10
 	breakingTorque = 15
-	maxTemp = 3000
 	explosionPotential = 0.25
+	
+	//Thermal Stuff
+	//Assuming same as Dynasoar
+	//Structure and skin made of Rene 41 (max temp 1144)
+	//Belly coated with Molybdenum (max temp ~2000)
+	//Nose made of graphite
+	//Very high emissivity paint applied to maximize radiation
+	heatConductivity = 0.25		//all conductivity
+	skinInternalConductionMult = 0.005	//skin-to-int conductivity
+	skinMassPerArea = 8.25 //1 mm Rene 41
+	thermalMassModifier = 2.0
+	emissiveConstant = 0.95		//matte black
+
+	maxTemp = 773	//delicate, lower int temp
+	skinMaxTemp = 2000
 
 	CoMOffset = 0.0, -0.1, 0.2
 	mirrorRefAxis = 0, 0, 0
@@ -184,4 +195,10 @@ PART
 //	===========================================================================
 
 
-
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-GeminiWing]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 2000
+}

--- a/GameData/ROCapsules/PartConfigs/Gemini/GeminiWing.cfg
+++ b/GameData/ROCapsules/PartConfigs/Gemini/GeminiWing.cfg
@@ -198,7 +198,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-GeminiWing]:FOR[RealismOverhaul]
+@PART[ROC-GeminiWing]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 2000
 }

--- a/GameData/ROCapsules/PartConfigs/Gemini/GeminiWingContSurf.cfg
+++ b/GameData/ROCapsules/PartConfigs/Gemini/GeminiWingContSurf.cfg
@@ -37,16 +37,28 @@ PART
 
 	// --- standard part parameters ---
 	mass = 0.02
-	thermalMassModifier = 4.0 // the dang things are light, so 3200 kJ/tonne-K
-	heatConductivity = 0.06 // half default
-	emissiveConstant = 0.95
 	dragModelType = none
 	maximum_drag = 0.02
 	minimum_drag = 0.02
 	angularDrag = 0.2
 	crashTolerance = 12
-	maxTemp = 3200
 	explosionPotential = 0.01
+
+	//Thermal Stuff
+	//Assuming same as Dynasoar
+	//Structure and skin made of Rene 41 (max temp 1144)
+	//Belly coated with Molybdenum (max temp ~2000)
+	//Nose made of graphite
+	//Very high emissivity paint applied to maximize radiation
+	heatConductivity = 0.25		//all conductivity
+	skinInternalConductionMult = 0.005	//skin-to-int conductivity
+	skinMassPerArea = 8.25 //1 mm Rene 41
+	thermalMassModifier = 2.0
+	emissiveConstant = 0.95		//matte black
+
+	maxTemp = 773	//delicate, lower int temp
+	skinMaxTemp = 2000
+
 
 // --- winglet parameters ---
 
@@ -70,5 +82,12 @@ PART
 		TaperRatio = 0.8512
 		maxdeflect = 20
 	}
+}
 
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-GeminiWingContSurf]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 2000
 }

--- a/GameData/ROCapsules/PartConfigs/Gemini/GeminiWingContSurf.cfg
+++ b/GameData/ROCapsules/PartConfigs/Gemini/GeminiWingContSurf.cfg
@@ -87,7 +87,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-GeminiWingContSurf]:FOR[RealismOverhaul]
+@PART[ROC-GeminiWingContSurf]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 2000
 }

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/BigG/BigGeminiCabin.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/BigG/BigGeminiCabin.cfg
@@ -37,13 +37,21 @@ PART
 	minimum_drag = 0.15
 	angularDrag = 2
 	crashTolerance = 20
-	maxTemp = 900
-	skinMaxTemp = 3350
-	heatConductivity = 0.1
-	thermalMassModifier = 1.0
 	vesselType = Ship
 	CrewCapacity = 7
 	bulkheadProfiles = size1p2, size2
+
+	//Thermal Stuff
+	//Skin made of Rene 41 shingles (max temp 1144), with beryllium shingles over hotspots (max temp 1273)
+	maxTemp = 773.15
+	skinMaxTemp = 2000					//Beryllium shingles (max temp 1273). Capsule takes a ton of flux. Tweak drag cubes? Raise this until then
+	emissiveConstant = 0.95				//Shingles coated in high emissivity ceramic paint
+	heatConductivity = 1.0				//All conductivity. Leave this alone for now
+	thermalMassModifier = 1.0			//Thermal mass. Leave this alone for now
+	skinInternalConductionMult = 0.005	//Skin-to-int conductivity. Tiles isloated from structure with spacers, and had gold coating on inside to minimize radiation.
+	skinMassPerArea = 13.15				//Beryllium 1.85 ton/m^3. 7.11 mm Beryllium, 13.15 kg/m^2?
+	skinThermalMassModifier = 1.0		//Skin thermal mass. Leave this alone for now
+	skinSkinConductionMult = 0.1		//Beryllium and Rene 41 are pretty conductive. Individual panels well isolated though.
 
 	tags = ?gemina 2.5 1.5 Gemini leo beale loaf bread
 
@@ -168,4 +176,12 @@ PART
 			}
 		}
 	}
+}
+
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-BigGeminiCabinBDB]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 2000		//Raising this until we can find a better way to deal with excess heat flux
 }

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/BigG/BigGeminiCabin.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/BigG/BigGeminiCabin.cfg
@@ -181,7 +181,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-BigGeminiCabinBDB]:FOR[RealismOverhaul]
+@PART[ROC-BigGeminiCabinBDB]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 2000		//Raising this until we can find a better way to deal with excess heat flux
 }

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/BigG/BigGeminiHSLunar.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/BigG/BigGeminiHSLunar.cfg
@@ -24,7 +24,7 @@ PART
 	subcategory = 0
 	title = Big Gemini Lunar Heat Shield
 	manufacturer = McDonnell Aircraft
-	description  = Heatshield for the Big Gemini capsule
+	description  = Lunar heatshield for the Big Gemini capsule.  <b><color=red>Gemini lacks the radiative heat protection of more advanced capsules. Extremely gentle Lunar reentries only.</color></b>
 	attachRules = 1,0,1,0,0
 	mass = 0.144
 	dragModelType = default

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiCM.cfg
@@ -43,12 +43,21 @@ PART
 	breakingForce = 72
 	breakingTorque = 72
 	crashTolerance = 20
-	skinMaxTemp = 3350
-	maxTemp = 900
-	emissiveConstant = 0.6 // shingles
 	vesselType = Ship
 	CrewCapacity = 2
 	bulkheadProfiles = size0, size1p2
+
+	//Thermal Stuff
+	//Skin made of Rene 41 shingles (max temp 1144), with beryllium shingles over hotspots (max temp 1273)
+	maxTemp = 773.15
+	skinMaxTemp = 2000					//Beryllium shingles (max temp 1273). Capsule takes a ton of flux. Tweak drag cubes? Raise this until then
+	emissiveConstant = 0.95				//Shingles coated in high emissivity ceramic paint
+	heatConductivity = 1.0				//All conductivity. Leave this alone for now
+	thermalMassModifier = 1.0			//Thermal mass. Leave this alone for now
+	skinInternalConductionMult = 0.005	//Skin-to-int conductivity. Tiles isloated from structure with spacers, and had gold coating on inside to minimize radiation.
+	skinMassPerArea = 13.15				//Beryllium 1.85 ton/m^3. 7.11 mm Beryllium, 13.15 kg/m^2?
+	skinThermalMassModifier = 1.0		//Skin thermal mass. Leave this alone for now
+	skinSkinConductionMult = 0.1		//Beryllium and Rene 41 are pretty conductive. Individual panels well isolated though.
 
 	tags = capsule pod gemini
 
@@ -404,3 +413,10 @@ PART
 	}
 }
 
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-GeminiCMBDB]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 2000		//Raising this until we can find a better way to deal with excess heat flux
+}

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiCM.cfg
@@ -81,7 +81,7 @@ PART
 	MODULE
 	{
 		name = AdjustableCoMShifter
-		DescentModeCoM = 0.0, 0.0, -0.06
+		DescentModeCoM = 0.0, 0.0, 0.06		//Gemini reentered "upside-down" to protect crew hatches
 	}
 
 	MODULE
@@ -416,7 +416,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-GeminiCMBDB]:FOR[RealismOverhaul]
+@PART[ROC-GeminiCMBDB]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 2000		//Raising this until we can find a better way to deal with excess heat flux
 }

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiHSLunar.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiHSLunar.cfg
@@ -2,7 +2,7 @@
 {
 	@name = ROC-GeminiHSLunarBDB
 	@title = Gemini Lunar Heatshield
-	@description = Improved, lunar rated heatshield for the Gemini Capsule. Can be switched to the Gemini B configuration with a hatch
+	@description = Improved, lunar rated heatshield for the Gemini Capsule. Can be switched to the Gemini B configuration with a hatch. <b><color=red>Gemini lacks the radiative heat protection of more advanced capsules. Extremely gentle Lunar reentries only.</color></b>
 	@heatShieldTag = Lunar
 	
 	DRAG_CUBE

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiNosecone.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiNosecone.cfg
@@ -43,14 +43,23 @@ PART
 	crashTolerance = 10
 	breakingForce = 50
 	breakingTorque = 50
-	maxTemp = 900
-	skinMaxTemp = 2000
-	emissiveConstant = 0.6 // shingles
 	fuelCrossFeed = False
 	stageOffset = 1
 	childStageOffset = 1
 	stagingIcon = DECOUPLER_VERT
 	bulkheadProfiles = size00, size0
+
+	//Thermal Stuff
+	//Skin made of Rene 41 shingles (max temp 1144), with beryllium shingles over hotspots (max temp 1273)
+	maxTemp = 773.15
+	skinMaxTemp = 1273					//Beryllium shingles (max temp 1273)
+	emissiveConstant = 0.95				//Shingles coated in high emissivity ceramic paint
+	heatConductivity = 1.0				//All conductivity. Leave this alone for now
+	thermalMassModifier = 1.0			//Thermal mass. Leave this alone for now
+	skinInternalConductionMult = 0.005	//Skin-to-int conductivity. Tiles isloated from structure with spacers, and had gold coating on inside to minimize radiation.
+	skinMassPerArea = 13.15				//Beryllium 1.85 ton/m^3. 7.11 mm Beryllium, 13.15 kg/m^2?
+	skinThermalMassModifier = 1.0		//Skin thermal mass. Leave this alone for now
+	skinSkinConductionMult = 0.1		//Beryllium and Rene 41 are pretty conductive. Individual panels well isolated though.
 
 	tags = gemini dock docking port gatv agena target
 
@@ -126,4 +135,12 @@ PART
 			}
 		}
 	}
+}
+
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-GeminiNoseconeBDB]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 1273
 }

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiNosecone.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiNosecone.cfg
@@ -140,7 +140,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-GeminiNoseconeBDB]:FOR[RealismOverhaul]
+@PART[ROC-GeminiNoseconeBDB]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 1273
 }

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiNoseconeAero.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiNoseconeAero.cfg
@@ -43,14 +43,23 @@ PART
 	crashTolerance = 10
 	breakingForce = 50
 	breakingTorque = 50
-	maxTemp = 900
-	skinMaxTemp = 2000
-	emissiveConstant = 0.6 // shingles
 	fuelCrossFeed = False
 	stageOffset = 1
 	childStageOffset = 1
 	stagingIcon = DECOUPLER_VERT
 	bulkheadProfiles = size00, size0
+
+	//Thermal Stuff
+	//Skin made of Rene 41 shingles (max temp 1144), with beryllium shingles over hotspots (max temp 1273)
+	maxTemp = 773.15
+	skinMaxTemp = 1273					//Beryllium shingles (max temp 1273)
+	emissiveConstant = 0.95				//Shingles coated in high emissivity ceramic paint
+	heatConductivity = 1.0				//All conductivity. Leave this alone for now
+	thermalMassModifier = 1.0			//Thermal mass. Leave this alone for now
+	skinInternalConductionMult = 0.005	//Skin-to-int conductivity. Tiles isloated from structure with spacers, and had gold coating on inside to minimize radiation.
+	skinMassPerArea = 13.15				//Beryllium 1.85 ton/m^3. 7.11 mm Beryllium, 13.15 kg/m^2?
+	skinThermalMassModifier = 1.0		//Skin thermal mass. Leave this alone for now
+	skinSkinConductionMult = 0.1		//Beryllium and Rene 41 are pretty conductive. Individual panels well isolated though.
 
 	tags = gemini dock docking port gatv agena target
 
@@ -76,4 +85,12 @@ PART
 			}
 		}
 	}
+}
+
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-GeminiNoseconeAeroBDB]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 1273
 }

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiNoseconeAero.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiNoseconeAero.cfg
@@ -90,7 +90,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-GeminiNoseconeAeroBDB]:FOR[RealismOverhaul]
+@PART[ROC-GeminiNoseconeAeroBDB]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 1273
 }

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiParachute.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiParachute.cfg
@@ -171,7 +171,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-GeminiParachuteBDB]:FOR[RealismOverhaul]
+@PART[ROC-GeminiParachuteBDB]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 1273
 }

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiParachute.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiParachute.cfg
@@ -39,13 +39,23 @@ PART
 	breakingForce = 50
 	breakingTorque = 50
 	bodyLiftMultiplier = 0
-	maxTemp = 900
-	skinMaxTemp = 2000
 	fuelCrossFeed = False
 	stageOffset = -1
 	childStageOffset = 1
 	stagingIcon = PARACHUTES
 	bulkheadProfiles = size0
+
+	//Thermal Stuff
+	//Skin made of Rene 41 shingles (max temp 1144), with beryllium shingles over hotspots (max temp 1273)
+	maxTemp = 773.15
+	skinMaxTemp = 1273					//Beryllium shingles (max temp 1273)
+	emissiveConstant = 0.95				//Shingles coated in high emissivity ceramic paint
+	heatConductivity = 1.0				//All conductivity. Leave this alone for now
+	thermalMassModifier = 1.0			//Thermal mass. Leave this alone for now
+	skinInternalConductionMult = 0.005	//Skin-to-int conductivity. Tiles isloated from structure with spacers, and had gold coating on inside to minimize radiation.
+	skinMassPerArea = 13.15				//Beryllium 1.85 ton/m^3. 7.11 mm Beryllium, 13.15 kg/m^2?
+	skinThermalMassModifier = 1.0		//Skin thermal mass. Leave this alone for now
+	skinSkinConductionMult = 0.1		//Beryllium and Rene 41 are pretty conductive. Individual panels well isolated though.
 
 	tags = gemini parachute descent landing
 
@@ -156,4 +166,12 @@ PART
 			@deploymentAlt = 2740
 		}
 	}
+}
+
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-GeminiParachuteBDB]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 1273
 }

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiParachuteDrogue.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiParachuteDrogue.cfg
@@ -41,7 +41,7 @@
 	angularDrag = 3
 	crashTolerance = 12
 	maxTemp = 900
-	skinMaxTemp = 2000
+	skinMaxTemp = 1073		//Shouldn't get exposed to airflow, leave alone
 	emissiveConstant = 0.7
 	stageOffset = -1
 	bulkheadProfiles = size0, srf

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiReentryControlSystem.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiReentryControlSystem.cfg
@@ -173,7 +173,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-ReentryControlSystemBDB]:FOR[RealismOverhaul]
+@PART[ROC-ReentryControlSystemBDB]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 1273
 }

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiReentryControlSystem.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiReentryControlSystem.cfg
@@ -34,11 +34,20 @@ PART
 	crashTolerance = 10
 	breakingForce = 50
 	breakingTorque = 50
-	skinMaxTemp = 3350
-	maxTemp = 900
-	emissiveConstant = 0.6 // shingles
 	//fuelCrossFeed = False
 	bulkheadProfiles = size0
+
+	//Thermal Stuff
+	//Skin made of Rene 41 shingles (max temp 1144), with beryllium shingles over hotspots (max temp 1273)
+	maxTemp = 773.15
+	skinMaxTemp = 1273					//Beryllium shingles (max temp 1273)
+	emissiveConstant = 0.95				//Shingles coated in high emissivity ceramic paint
+	heatConductivity = 1.0				//All conductivity. Leave this alone for now
+	thermalMassModifier = 1.0			//Thermal mass. Leave this alone for now
+	skinInternalConductionMult = 0.005	//Skin-to-int conductivity. Tiles isloated from structure with spacers, and had gold coating on inside to minimize radiation.
+	skinMassPerArea = 13.15				//Beryllium 1.85 ton/m^3. 7.11 mm Beryllium, 13.15 kg/m^2?
+	skinThermalMassModifier = 1.0		//Skin thermal mass. Leave this alone for now
+	skinSkinConductionMult = 0.1		//Beryllium and Rene 41 are pretty conductive. Individual panels well isolated though.
 
 	tags = gemini rcs reentry control
 
@@ -159,4 +168,12 @@ PART
 			}
 		}
 	}
+}
+
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-ReentryControlSystemBDB]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 1273
 }

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryAirbrake.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryAirbrake.cfg
@@ -133,7 +133,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-MercuryAirbrakeBDB]:FOR[RealismOverhaul]
+@PART[ROC-MercuryAirbrakeBDB]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 1144
 }

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryAirbrake.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryAirbrake.cfg
@@ -45,6 +45,22 @@ PART
 	bulkheadProfiles = size0
 	bodyLiftMultiplier = 0
 
+	//Thermal Stuff
+	//Skin made of Rene 41 shingles (max temp 1144)
+	//Peak temp on HS: ~2000 K
+	//Peak temp on Walls: ~977 K
+	//Peak temp on forward surfaces: ~600 K
+	//Peak interior temp: ~315 K
+	maxTemp = 1144						//Probably just solid Rene 41
+	skinMaxTemp = 1144					//Rene 41 shingles (max temp 1144)
+	emissiveConstant = 0.95				//Shingles coated in high emissivity ceramic paint
+	heatConductivity = 1.0				//All conductivity. Leave this alone for now
+	thermalMassModifier = 1.0			//Thermal mass. Leave this alone for now
+	skinInternalConductionMult = 0.01	//Just a solid piece of metal?
+	skinMassPerArea = 3.38				//Rene 41 8.24 ton/m^3. 0.41 mm Rene 41, 3.38 kg/m^2?
+	skinThermalMassModifier = 1.0		//Skin thermal mass. Leave this alone for now
+	skinSkinConductionMult = 0.1		//Rene 41 is pretty conductive, and heat sink needed to spread heat. Individual panels well isolated though.
+
 	tags = mercury aero stablizer airbrake
 
 
@@ -112,5 +128,12 @@ PART
 			}
 		}
 	}
+}
 
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-MercuryAirbrakeBDB]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 1144
 }

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryCM.cfg
@@ -535,7 +535,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-MercuryCMBDB]:FOR[RealismOverhaul]
+@PART[ROC-MercuryCMBDB]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 1144
 }

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryCM.cfg
@@ -49,15 +49,25 @@ PART
 	minimum_drag = 0.15
 	angularDrag = 2
 	crashTolerance = 8
-	bodyLiftMultiplier = 0
+
+	//Thermal Stuff
+	//Skin made of Rene 41 shingles (max temp 1144)
+	//Peak temp on HS: ~2000 K
+	//Peak temp on Walls: ~977 K
+	//Peak temp on forward surfaces: ~600 K
+	//Peak interior temp: ~315 K
 	maxTemp = 773.15
-	skinMaxTemp = 2573.15
-	emissiveConstant = 0.9 // not too absorptive for reentry
-	thermalMassModifier = 1.0
-	skinMassPerArea = 2.0
+	skinMaxTemp = 1144					//Rene 41 shingles (max temp 1144)
+	emissiveConstant = 0.95				//Shingles coated in high emissivity ceramic paint
+	heatConductivity = 1.0				//All conductivity. Leave this alone for now
+	thermalMassModifier = 1.0			//Thermal mass. Leave this alone for now
+	skinInternalConductionMult = 0.005	//Skin-to-int conductivity. Tiles isloated from structure with spacers, and had gold coating on inside to minimize radiation.
+	skinMassPerArea = 3.38				//Rene 41 8.24 ton/m^3. 0.41 mm Rene 41, 3.38 kg/m^2?
+	skinThermalMassModifier = 1.0		//Skin thermal mass. Leave this alone for now
+	skinSkinConductionMult = 0.2		//Rene 41 is pretty conductive, and heat sink needed to spread heat. Individual panels well isolated though. Increase to help soak more heat from HS.
+
 	breakingForce = 250
 	breakingTorque = 250
-	skinInternalConductionMult = 6
 	vesselType = Ship
 	CrewCapacity = 1
 	bulkheadProfiles = size0, size1
@@ -65,7 +75,6 @@ PART
 	fuelCrossFeed = true
 
 	tags = mercury crew pod CM
-
 
 	EFFECTS
 	{
@@ -524,10 +533,18 @@ PART
 }
 
 //	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-MercuryCMBDB]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 1144
+}
+
+//	================================================================================
 //	Final Pass to Make Sure TAC does not add extra resources
 //	================================================================================
 
-@PART[ROC-MercuryCM]:BEFORE[zzzRealismOverhaul]
+@PART[ROC-MercuryCMBDB]:BEFORE[zzzRealismOverhaul]
 {
 	!RESOURCE:HAS[~name[Ablator],~name[CharredAblator]],*{}
 }

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryNoseCap.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryNoseCap.cfg
@@ -36,12 +36,26 @@ PART
 	dragModelType = default
 	angularDrag = 3
 	crashTolerance = 12
-	maxTemp = 2500 // = 3100
-	emissiveConstant = 0.7
 	stageOffset = 1
 	childStageOffset = 1
 	bulkheadProfiles = size0
 	bodyLiftMultiplier = 0
+
+	//Thermal Stuff
+	//Skin made of Rene 41 shingles (max temp 1144)
+	//Peak temp on HS: ~2000 K
+	//Peak temp on Walls: ~977 K
+	//Peak temp on forward surfaces: ~600 K
+	//Peak interior temp: ~315 K
+	maxTemp = 773.15
+	skinMaxTemp = 1144					//Rene 41 shingles (max temp 1144)
+	emissiveConstant = 0.95				//Shingles coated in high emissivity ceramic paint
+	heatConductivity = 1.0				//All conductivity. Leave this alone for now
+	thermalMassModifier = 1.0			//Thermal mass. Leave this alone for now
+	skinInternalConductionMult = 0.005	//Skin-to-int conductivity. Tiles isloated from structure with spacers, and had gold coating on inside to minimize radiation.
+	skinMassPerArea = 3.38				//Rene 41 8.24 ton/m^3. 0.41 mm Rene 41, 3.38 kg/m^2?
+	skinThermalMassModifier = 1.0		//Skin thermal mass. Leave this alone for now
+	skinSkinConductionMult = 0.1		//Rene 41 is pretty conductive, and heat sink needed to spread heat. Individual panels well isolated though.
 
 	tags = mercury hermes antenna
 
@@ -228,4 +242,12 @@ PART
 			@deploymentAlt = 5000
 		}
 	}
+}
+
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-MercuryNoseCapBDB]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 1144
 }

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryNoseCap.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryNoseCap.cfg
@@ -247,7 +247,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-MercuryNoseCapBDB]:FOR[RealismOverhaul]
+@PART[ROC-MercuryNoseCapBDB]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 1144
 }

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryRCS.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryRCS.cfg
@@ -323,7 +323,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-MercuryRCSBDB]:FOR[RealismOverhaul]
+@PART[ROC-MercuryRCSBDB]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 1144
 }

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryRCS.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryRCS.cfg
@@ -49,13 +49,25 @@ PART
 	crashTolerance = 12
 	breakingForce = 50
 	breakingTorque = 50
-	maxTemp = 773.15
-	skinMaxTemp = 2573.15
 	fuelCrossFeed = True
 	bodyLiftMultiplier = 0
 	bulkheadProfiles = size0
 
-	fuelCrossFeed = true
+	//Thermal Stuff
+	//Skin made of Rene 41 shingles (max temp 1144)
+	//Peak temp on HS: ~2000 K
+	//Peak temp on Walls: ~977 K
+	//Peak temp on forward surfaces: ~600 K
+	//Peak interior temp: ~315 K
+	maxTemp = 773.15
+	skinMaxTemp = 1144					//Rene 41 shingles (max temp 1144)
+	emissiveConstant = 0.95				//Shingles coated in high emissivity ceramic paint
+	heatConductivity = 1.0				//All conductivity. Leave this alone for now
+	thermalMassModifier = 1.0			//Thermal mass. Leave this alone for now
+	skinInternalConductionMult = 0.005	//Skin-to-int conductivity. Tiles isloated from structure with spacers, and had gold coating on inside to minimize radiation.
+	skinMassPerArea = 3.38				//Rene 41 8.24 ton/m^3. 0.41 mm Rene 41, 3.38 kg/m^2?
+	skinThermalMassModifier = 1.0		//Skin thermal mass. Leave this alone for now
+	skinSkinConductionMult = 0.1		//Rene 41 is pretty conductive, and heat sink needed to spread heat. Individual panels well isolated though.
 
 	tags = mercury rcs parachute control
 
@@ -306,4 +318,12 @@ PART
 	{
 		%crossfeedStatus = true
 	}
+}
+
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-MercuryRCSBDB]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 1144
 }

--- a/GameData/ROCapsules/PartConfigs/Orion/OrionCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/Orion/OrionCM.cfg
@@ -71,12 +71,21 @@ PART
 	breakingTorque = 500000
 	linearStrength = 9300000
 	angularStrength = 9300000
-	maxTemp = 800
-	skinMaxTemp = 3600
-	thermalMassModifier = 3.0
-	heatConductivity = 0.32
 	fuelCrossFeed = False
 	stagingIcon = COMMAND_POD
+	
+	//Thermal Stuff
+	//Skin made of Titanium, coated with TUFI and AETB-8 tiles, and AFRSI blankets
+	maxTemp = 773
+	skinMaxTemp = 1533					//Approximate maximum temp of shuttle HSRI tiles
+	emissiveConstant = 0.4				//Metallicized Klapton coating?
+	heatConductivity = 1.0				//All conductivity. Leave this alone for now
+	thermalMassModifier = 1.0			//Thermal mass. Leave this alone for now
+	skinInternalConductionMult = 0.005	//Skin-to-int conductivity. Skin coated in shuttle-grade tiles and blankets, very well insulated
+	skinMassPerArea = 19.2				//25 mm TUFI tiles? Assuming at shuttle density of 12 lbs/ft^3, 19.2 kg/m^2
+	skinThermalMassModifier = 1.0		//Skin thermal mass. Leave this alone for now
+	skinSkinConductionMult = 0.005		//Skin extremely well insulated and isolated. Probably not much conduction.
+	//Unfortunately, the drag cubes are broken and the CM takes full heating from reentry.
 
 	CrewCapacity = 6
 
@@ -336,4 +345,12 @@ PART
 			Ratio = 0.1
 		}
 	}
+}
+
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-OrionCM]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 3600		//Drag cubes are incorrect, and CM takes full heating. Unable to refine further at the moment
 }

--- a/GameData/ROCapsules/PartConfigs/Orion/OrionCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/Orion/OrionCM.cfg
@@ -350,7 +350,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-OrionCM]:FOR[RealismOverhaul]
+@PART[ROC-OrionCM]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 3600		//Drag cubes are incorrect, and CM takes full heating. Unable to refine further at the moment
 }

--- a/GameData/ROCapsules/PartConfigs/Orion/OrionForwardHS.cfg
+++ b/GameData/ROCapsules/PartConfigs/Orion/OrionForwardHS.cfg
@@ -49,10 +49,6 @@ PART
 	minimum_drag = 0.2
 	angularDrag = 2
 	crashTolerance = 12
-	maxTemp = 1200
-	skinMaxTemp = 2000
-	thermalMassModifier = 4.0
-	heatConductivity = 0.02
 	stageAfter = True
 	stageBefore = True
 	breakingForce = 500000
@@ -61,7 +57,19 @@ PART
 	angularStrength = 9300000
 	fuelCrossFeed = True
 	bulkheadProfiles = size0 //, srf
-
+	
+	//Thermal Stuff
+	//Skin made of Titanium, coated with TUFI and AETB-8 tiles, and AFRSI blankets
+	maxTemp = 773
+	skinMaxTemp = 1533					//Approximate maximum temp of shuttle HSRI tiles
+	emissiveConstant = 0.4				//Metallicized Klapton coating?
+	heatConductivity = 1.0				//All conductivity. Leave this alone for now
+	thermalMassModifier = 1.0			//Thermal mass. Leave this alone for now
+	skinInternalConductionMult = 0.005	//Skin-to-int conductivity. Skin coated in shuttle-grade tiles and blankets, very well insulated
+	skinMassPerArea = 19.2				//25 mm TUFI tiles? Assuming at shuttle density of 12 lbs/ft^3, 19.2 kg/m^2
+	skinThermalMassModifier = 1.0		//Skin thermal mass. Leave this alone for now
+	skinSkinConductionMult = 0.005		//Skin extremely well insulated and isolated. Probably not much conduction.
+	//Unfortunately, the drag cubes are broken and the CM takes full heating from reentry.
 
 	MODULE
 	{
@@ -135,4 +143,12 @@ PART
 			}
 		}
 	}
+}
+
+//	================================================================================
+//	Override RO global settings to get our temperatures back
+//	================================================================================
+@PART[ROC-OrionForwardHS]:FOR[RealismOverhaul]
+{
+	@skinMaxTemp = 3600		//Drag cubes are ancorrect, and CM takes full heating. Unable to refine further at the moment
 }

--- a/GameData/ROCapsules/PartConfigs/Orion/OrionForwardHS.cfg
+++ b/GameData/ROCapsules/PartConfigs/Orion/OrionForwardHS.cfg
@@ -148,7 +148,7 @@ PART
 //	================================================================================
 //	Override RO global settings to get our temperatures back
 //	================================================================================
-@PART[ROC-OrionForwardHS]:FOR[RealismOverhaul]
+@PART[ROC-OrionForwardHS]:AFTER[RealismOverhaul]
 {
 	@skinMaxTemp = 3600		//Drag cubes are ancorrect, and CM takes full heating. Unable to refine further at the moment
 }


### PR DESCRIPTION
Update capsule thermal properties, and patch maxTemps after RO global patches run. Everything now works mostly correctly, except for:
Gemini needs inflated skinMaxTemp due to receiving excessive convective flux. Drag cube issue?

Orion HS does not occlude Orion CM, which consequently cannot properly survive reentry. Drag cube issue.

resolves #104 