### PR TITLE
Flip Apollo to fix thermals

### DIFF
--- a/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloCMBlockIII+.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloCMBlockIII+.cfg
@@ -178,7 +178,8 @@ PART
 	MODULE
 	{
 		name = AdjustableCoMShifter
-		DescentModeCoM = 0, 0, 0.17	//Apollo should reenter "upside-down" to protect crew hatch
+		DescentModeCoM = 0, 0, -0.17	//Apollo should reenter "windows-down" to protect crew hatch
+		//However, doing so causes the CM to take full heating and die. Just go back to being upside-down, hopefully (eventually) switching the BDB Apollo will fix.
 	}
 
 	MODULE

--- a/GameData/ROCapsules/PartConfigs/Apollo/ApolloCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo/ApolloCM.cfg
@@ -145,7 +145,8 @@ PART
 	MODULE
 	{
 		name = AdjustableCoMShifter
-		DescentModeCoM = 0, 0, 0.17	//Apollo should reenter "upside-down" to protect crew hatch
+		DescentModeCoM = 0, 0, -0.17	//Apollo should reenter "windows-down" to protect crew hatch
+		//However, doing so causes the CM to take full heating and die. Just go back to being upside-down, hopefully (eventually) switching the BDB Apollo will fix.
 	}
 
 	MODULE


### PR DESCRIPTION
For some reason, when Apollo is oriented "correctly" (windows down) for lifting reentry, the CM takes full heating and the HS takes none. Switching to windows up reentry makes it behave correctly, so just do that until someone comes up with a better solution (BDB Apollo, probably).
