### PR TITLE
Fix authors list in metanetkan

### DIFF
--- a/ROCapsules.netkan
+++ b/ROCapsules.netkan
@@ -6,7 +6,7 @@
     "name"           : "ROCapsules",
     "identifier"     : "ROCapsules",
     "abstract"       : "ROCapsules is a mod that takes the best versions of capsules available and uses them as the in-game models for Realism Overhaul parts.",
-    "author"         : "pap1723,KSP-RO",
+    "author"         : [ "pap1723", "KSP-RO" ],
     "license"        : "CC-BY-SA",
     "release_status" : "stable",
     "depends" : [


### PR DESCRIPTION
While reviewing KSP-CKAN/NetKAN#9193 I noticed the `author` property now had a comma in it. When there are multiple authors, it's supposed to be a JSON list, not a comma-delimited string. Now that's fixed.

Tagging @NathanKell because GitHub doesn't think pull requests are important enough to ping people by default.