### PR TITLE
CLS Support

### DIFF
--- a/GameData/ROCapsules/PartConfigs/APAS/APAS_Active.cfg
+++ b/GameData/ROCapsules/PartConfigs/APAS/APAS_Active.cfg
@@ -64,6 +64,14 @@ PART
 		undockEjectionForce = 0.1 // 10
 	}
 
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
+
 	MODULE
 	{
 		name = ModuleAnimateGeneric

--- a/GameData/ROCapsules/PartConfigs/APAS/APAS_Passive.cfg
+++ b/GameData/ROCapsules/PartConfigs/APAS/APAS_Passive.cfg
@@ -65,5 +65,11 @@ PART
 		undockEjectionForce = 0.1 // 10
 	}
 
-
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
 }

--- a/GameData/ROCapsules/PartConfigs/Apollo D2/D2CommandModule.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo D2/D2CommandModule.cfg
@@ -251,6 +251,15 @@ PART
 		charModuleName = shieldChar
 	}
 
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+		impassablenodes = bottom
+	}
+
 	//	============================================================================
 	//	Animations and Textures
 	//	============================================================================

--- a/GameData/ROCapsules/PartConfigs/Apollo D2/D2DockDrogue.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo D2/D2DockDrogue.cfg
@@ -81,4 +81,12 @@ PART
 		minDistanceToReEngage = 0.25 // 1.0
 		undockEjectionForce = 0.1
 	}
+
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
 }

--- a/GameData/ROCapsules/PartConfigs/Apollo D2/D2DockProbe.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo D2/D2DockProbe.cfg
@@ -82,4 +82,12 @@ PART
 		minDistanceToReEngage = 0.25 // 1.0
 		undockEjectionForce = 0.1
 	}
+
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
 }

--- a/GameData/ROCapsules/PartConfigs/Apollo D2/D2MissionModule1.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo D2/D2MissionModule1.cfg
@@ -92,6 +92,14 @@ PART
 		useMultipleDragCubes = false
 	}
 
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
+
 	MODULE
 	{
 		name = ModuleFuelTanks

--- a/GameData/ROCapsules/PartConfigs/Apollo D2/D2MissionModule2.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo D2/D2MissionModule2.cfg
@@ -93,6 +93,14 @@ PART
 		useMultipleDragCubes = false
 	}
 
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
+
 	MODULE
 	{
 		name = ModuleFuelTanks

--- a/GameData/ROCapsules/PartConfigs/Apollo D2/D2Parachute.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo D2/D2Parachute.cfg
@@ -155,6 +155,14 @@ PART
 		maxAmount = 12
 		amount = 12
 	}
+
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
 }
 
 @PART[ROC-D2Parachute]:AFTER[zzzRealismOverhaul]

--- a/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloActiveDockingMechanism.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloActiveDockingMechanism.cfg
@@ -81,6 +81,14 @@ PART
 		undockEjectionForce = 0.1 // 10
 	}
 
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
+
 	MODULE
 	{
 		name = ModuleAnimateGeneric

--- a/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloCMBlockIII+.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloCMBlockIII+.cfg
@@ -238,8 +238,10 @@ PART
 	MODULE:NEEDS[ConnectedLivingSpace]
 	{
 		name = ModuleConnectedLivingSpace
-		passable = true
-		impassablenodes = para, para2, bottom
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+		impassablenodes = para, para2
 	}
 
 	MODULE

--- a/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloMissionModule.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloMissionModule.cfg
@@ -115,6 +115,14 @@ PART
 		endEventGUIName = Spotlight Off
 		defaultActionGroup = Light
 	}
+
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
 }
 
 +PART[ROC-ApolloMissionModule]:FIRST

--- a/GameData/ROCapsules/PartConfigs/Apollo/ApolloCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo/ApolloCM.cfg
@@ -381,8 +381,10 @@ PART
 	MODULE:NEEDS[ConnectedLivingSpace]
 	{
 		name = ModuleConnectedLivingSpace
-		passable = true
-		impassablenodes = para, para2, bottom
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+		impassablenodes = para, para2
 	}
 	
 	MODULE

--- a/GameData/ROCapsules/PartConfigs/Apollo/ApolloDrogueDockPort.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo/ApolloDrogueDockPort.cfg
@@ -93,6 +93,8 @@ PART
 	{
 		name = ModuleConnectedLivingSpace
 		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
 	}
 
 	MODULE

--- a/GameData/ROCapsules/PartConfigs/Apollo/ApolloForwardHS.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo/ApolloForwardHS.cfg
@@ -122,6 +122,8 @@ PART
 	{
 		name = ModuleConnectedLivingSpace
 		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
 	}
 	
 	//	============================================================================

--- a/GameData/ROCapsules/PartConfigs/CST/CSTCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/CST/CSTCM.cfg
@@ -198,6 +198,14 @@ PART
 		}
 	}
 
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
+
 	MODULE
 	{
 		name = ModuleFuelTanks

--- a/GameData/ROCapsules/PartConfigs/CST/CSTNDSActive.cfg
+++ b/GameData/ROCapsules/PartConfigs/CST/CSTNDSActive.cfg
@@ -81,6 +81,14 @@ PART
 		undockEjectionForce = 0.1
 		stagingEnabled = False
 	}
+
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
 }
 
 @PART[ROC-CSTNDSActive]:AFTER[FerramAerospaceResearch]

--- a/GameData/ROCapsules/PartConfigs/CST/CSTNDSPassive.cfg
+++ b/GameData/ROCapsules/PartConfigs/CST/CSTNDSPassive.cfg
@@ -81,6 +81,14 @@ PART
 		undockEjectionForce = 0.1
 		stagingEnabled = False
 	}
+
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
 }
 
 @PART[ROC-CSTNDSPassive]:AFTER[FerramAerospaceResearch]

--- a/GameData/ROCapsules/PartConfigs/CST/CSTParachute.cfg
+++ b/GameData/ROCapsules/PartConfigs/CST/CSTParachute.cfg
@@ -138,6 +138,14 @@ PART
 		}
 	}
 
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
+
 	MODULE
 	{
 		name = ModuleDragModifier

--- a/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaAftBayMoroz.cfg
+++ b/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaAftBayMoroz.cfg
@@ -22,6 +22,7 @@ PART
 	cost = 1
 	category = Structural
 	subcategory = 0
+	CrewCapacity = 1
 	title = Dynasoar Aft Bay
 	manufacturer = Boeing
 	description = The aft bay and adapter for Dynasoar, containing liquid hydrogen and liquid oxygen for the fuel cells, space for extra supplies and equipment, and a crew tube. Rated for high altitude hypersonic flight, but decouple before reentry.
@@ -67,6 +68,14 @@ PART
 		crossfeedStatus = true
 		toggleEditor = true
 		toggleFlight = true
+	}
+	
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
 	}
 	
 	MODULE

--- a/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaBayMoroz.cfg
+++ b/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaBayMoroz.cfg
@@ -85,6 +85,15 @@ PART
 		nodeInnerAftID = rearInner
 	}
 
+	//Strictly this shouldn't be passable, but the crew tube mounts to the bay, so this needs to be passable for the crew tube
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
+
 	MODULE
 	{
 		name = ModulePartVariants

--- a/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaButtMoroz.cfg
+++ b/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaButtMoroz.cfg
@@ -53,7 +53,15 @@ PART
 	skinMaxTemp = 2000
 
 	tags = X20 x-20 dynasoar equipment compartment fuel cell service aircraft dynamic soarer
-	
+
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
+
 	MODULE
 	{
 		name = ModuleFuelTanks

--- a/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaCabinMoroz.cfg
+++ b/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaCabinMoroz.cfg
@@ -122,7 +122,14 @@ PART
 		}
 	}
 
-	
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
+
 	MODULE
 	{
 		name = ModuleFuelTanks

--- a/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaCockpitMoroz.cfg
+++ b/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaCockpitMoroz.cfg
@@ -99,6 +99,14 @@ PART
 		}
 	}
 
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
+
 	//Nothing mentions a HTP tank in the nose, but there's a lot of empty space there
 	//And something is needed to balance out rear HTP tanks to keep CoM shift less than 0.9%
 	MODULE

--- a/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaCrewTubeMoroz.cfg
+++ b/GameData/ROCapsules/PartConfigs/DynasoarMoroz/DynaCrewTubeMoroz.cfg
@@ -42,6 +42,14 @@ PART
 	bulkheadProfiles = mk2
 	tags = X20 x-20 dynasoar crew docking aircraft dynamic soarer
 	
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
+	
 	MODULE
 	{
 		name = ModulePartVariants

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/BigG/BigGeminiCabin.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/BigG/BigGeminiCabin.cfg
@@ -153,6 +153,14 @@ PART
 		textureQuadName = flagTexture
 	}
 
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/BigG/BigGeminiDecoupler.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/BigG/BigGeminiDecoupler.cfg
@@ -73,4 +73,12 @@ PART
 		actionGUIName = Toggle Umbilicals
 		allowAnimationWhileShielded = True
 	}
+
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
 }

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/BigG/BigGeminiDockingAdapter.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/BigG/BigGeminiDockingAdapter.cfg
@@ -38,4 +38,11 @@ PART
 	bulkheadProfiles = size1p2, size1p5
 	tags = MOL MOS Gemini leo docking adapter structural ferry
 
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
 }

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/BigG/BigGeminiHS.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/BigG/BigGeminiHS.cfg
@@ -66,4 +66,12 @@ PART
 			transform = MOL_Hatch
 		}
 	}
+
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
 }

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/BigG/BigGeminiHSLunar.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/BigG/BigGeminiHSLunar.cfg
@@ -69,4 +69,12 @@ PART
 			transform = MOL_Hatch
 		}
 	}
+
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
 }

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/BigG/BigGeminiMOLPort.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/BigG/BigGeminiMOLPort.cfg
@@ -70,4 +70,11 @@ PART
 		allowAnimationWhileShielded = False
 	}
 
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
 }

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/BigG/BigGeminiSM.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/BigG/BigGeminiSM.cfg
@@ -47,6 +47,14 @@ PART
 		name = crewCabinInternals
 	}
 
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
+
 	MODULE
 	{
 		name = ModuleFuelTanks

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiB/GeminiBEquipmentSection.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiB/GeminiBEquipmentSection.cfg
@@ -112,6 +112,14 @@ PART
 		}
 	}
 	
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
+	
 	RESOURCE
 	{
 		name = PSPC

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiB/GeminiBRetrogradeSection.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiB/GeminiBRetrogradeSection.cfg
@@ -98,4 +98,12 @@ PART
 		ejectionForce = 10
 		staged = True
 	}
+	
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
 }

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiCM.cfg
@@ -135,6 +135,15 @@ PART
 		packetCeiling = 5
 	}
 
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+		//impassablenodes = top
+	}
+
 	MODULE
 	{
 		name = ModuleColorChanger

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiHS.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiHS.cfg
@@ -66,4 +66,12 @@ PART
 			transform = MOL_Hatch
 		}
 	}
+
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
 }

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiLCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiLCM.cfg
@@ -135,6 +135,15 @@ PART
 		packetCeiling = 5
 	}
 
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+		impassablenodes = top
+	}
+
 	MODULE
 	{
 		name = ModuleColorChanger

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiRetrogradeDecoupler.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiRetrogradeDecoupler.cfg
@@ -64,4 +64,12 @@ PART
 		toggleEditor = true
 		toggleFlight = true
 	}
+	
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
 }

--- a/GameData/ROCapsules/PartConfigs/LEM/LEMAscent.cfg
+++ b/GameData/ROCapsules/PartConfigs/LEM/LEMAscent.cfg
@@ -227,7 +227,9 @@ PART
 	MODULE:NEEDS[ConnectedLivingSpace]
 	{
 		name = ModuleConnectedLivingSpace
-		passable = true
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
 		impassablenodes = bottom
 	}
 

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryCM.cfg
@@ -400,6 +400,15 @@ PART
 		}
 	}
 
+	//Actually had emergency escape hatch in nose. Leave nose node passable.
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
+
 	MODULE
 	{
 		name = ModuleFuelTanks

--- a/GameData/ROCapsules/PartConfigs/Orion/OrionCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/Orion/OrionCM.cfg
@@ -176,6 +176,15 @@ PART
 		
 	}
 
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+		impassablenodes = PARA
+	}
+
 	PhysicsSignificance = 1
 
 	

--- a/GameData/ROCapsules/PartConfigs/Orion/OrionForwardHS.cfg
+++ b/GameData/ROCapsules/PartConfigs/Orion/OrionForwardHS.cfg
@@ -98,6 +98,14 @@ PART
 		explosiveNodeID = bottom
 	}
 
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+	}
+
 	MODULE
 	{
 		name = ModuleDragModifier

--- a/GameData/ROCapsules/PartConfigs/Vostok/VoskhodAirlock.cfg
+++ b/GameData/ROCapsules/PartConfigs/Vostok/VoskhodAirlock.cfg
@@ -23,10 +23,8 @@ PART
 	scale = 1.0
 	rescaleFactor = 1.0
 
-	//node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
-	//node_stack_top = 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1
-	//Convert to surface attach, otherwise CLS doesn't work.
-	node_attach = 0.0, 0.0, 0.15, 0.0, -0.4, 1.0, 1
+	node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+	//node_attach = 0.0, 0.0, 0.15, 0.0, -0.4, 1.0, 1
 
 	attachRules = 1,1,1,1,0
 
@@ -71,7 +69,8 @@ PART
 	//	Modules and Resources
 	//	============================================================================
 
-	MODULE
+	//Kerbalism will control the animation itself if present (assuming someone fixed the config)
+	MODULE:NEEDS[!Kerbalism]
 	{
 		name = ModuleAnimateGeneric
 		animationName = Deploy

--- a/GameData/ROCapsules/PartConfigs/Vostok/VoskhodAirlock.cfg
+++ b/GameData/ROCapsules/PartConfigs/Vostok/VoskhodAirlock.cfg
@@ -23,9 +23,12 @@ PART
 	scale = 1.0
 	rescaleFactor = 1.0
 
-	node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+	//node_stack_bottom = 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1
+	//node_stack_top = 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1
+	//Convert to surface attach, otherwise CLS doesn't work.
+	node_attach = 0.0, 0.0, 0.15, 0.0, -0.4, 1.0, 1
 
-	attachRules = 1,0,1,1,0
+	attachRules = 1,1,1,1,0
 
 	fx_gasBurst_white = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, decouple
 	sound_decoupler_fire = decouple
@@ -156,7 +159,9 @@ PART
 	MODULE:NEEDS[ConnectedLivingSpace]
 	{
 		name = ModuleConnectedLivingSpace
-		passable = true
+		passable = True
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
 	}
 }
 

--- a/GameData/ROCapsules/PartConfigs/Vostok/VoskhodCapsule.cfg
+++ b/GameData/ROCapsules/PartConfigs/Vostok/VoskhodCapsule.cfg
@@ -128,7 +128,9 @@ PART
 	{
 		name = ModuleConnectedLivingSpace
 		passable = true
-		impassablenodes = bottom
+		passableWhenSurfaceAttached = true
+		surfaceAttachmentsPassable = true
+		impassablenodes = bottom, top, para
 	}
 
 	MODULE:NEEDS[RasterPropMonitor]

--- a/GameData/ROCapsules/PartConfigs/Vostok/VostokCapsule.cfg
+++ b/GameData/ROCapsules/PartConfigs/Vostok/VostokCapsule.cfg
@@ -97,6 +97,12 @@ PART
 		storageRange = 3.0
 	}
 
+	MODULE:NEEDS[ConnectedLivingSpace]
+	{
+		name = ModuleConnectedLivingSpace
+		passable = false
+	}
+
 	MODULE
 	{
 		name = ModuleFuelTanks
@@ -126,7 +132,7 @@ PART
 	{
 		name = ModuleConnectedLivingSpace
 		passable = true
-		impassablenodes = bottom
+		impassablenodes = bottom, para
 	}
 
 	MODULE:NEEDS[RasterPropMonitor]


### PR DESCRIPTION
Restore CLS support to ROCapsules. Unfortunately, the Apollo Docking Ports and the Voskhod airlock do not function correctly with CLS, and register as impassable. The Voskhod docking port has been changed to surface-attach to fix it.

Requires https://github.com/KSP-RO/ROKerbalism/pull/126