### PR TITLE
Vostok/Voskhod Overhaul

### DIFF
--- a/GameData/ROCapsules/PartConfigs/Vostok/RP_Support_Vostok.cfg
+++ b/GameData/ROCapsules/PartConfigs/Vostok/RP_Support_Vostok.cfg
@@ -1,0 +1,25 @@
+@PART[ROC-VoskhodCapsule]:BEFORE[RealPlume]
+{
+	PLUME
+	{
+		name = Solid-Sepmotor
+		transformName = newThrustTransform
+		plumePosition = 0.0, 0.0, 0.0
+		plumeScale = 0.25
+		flarePosition = 0.0, 0.0, 0.0
+		flareScale = 1.0
+		smokePosition = 0.0, 0.0, 0.0
+		smokeScale = 1.0
+		slagPosition = 0.0, 0.0, 0.0
+		slagScale = 1.0
+		localRotation = 0.0, 0.0, 0.0
+		emissionMult = 0.5
+		energy = 1.0
+		speed = 1.25
+	}
+
+	@MODULE[ModuleEnginesRF]:HAS[#thrustVectorTransformName[newThrustTransform]]
+	{
+		%powerEffectName = Solid-Sepmotor
+	}
+}

--- a/GameData/ROCapsules/PartConfigs/Vostok/VoskhodAirlock.cfg
+++ b/GameData/ROCapsules/PartConfigs/Vostok/VoskhodAirlock.cfg
@@ -40,7 +40,7 @@ PART
 	category = Utility
 	subcategory = 0
 	title = Voskhod Airlock
-	manufacturer = OKB-1
+	manufacturer = #roMfrOKB1
 	description = The Voskhod Airlock will allow for your crew to perform an EVA from the Voskhod airlock. Attach this to the node on the side of the Voskhod capsule. Transfer your crew memeber inside and perform your EVA. Be sure to decouple this before re-entry.
 	tags = soviet, capsule, crew, voskhod, airlock, eva
 
@@ -51,7 +51,7 @@ PART
 	//	Thermo, Durability
 	//	============================================================================
 
-	mass = 0.339
+	mass = 0.250
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.2

--- a/GameData/ROCapsules/PartConfigs/Vostok/VoskhodCapsule.cfg
+++ b/GameData/ROCapsules/PartConfigs/Vostok/VoskhodCapsule.cfg
@@ -14,6 +14,12 @@ PART
 	{
 		model = ROCapsules/Assets/RN/voskhod_sc
 	}
+	MODEL
+	{
+		model = RealismOverhaul/emptyengine
+		position = 0.0, -1.12398, 0.0
+		rotation = 0.0, 0.0, 0.0
+	}
 
 	INTERNAL
 	{
@@ -42,7 +48,7 @@ PART
 	category = Pods
 	subcategory = 0
 	title = Voskhod Descent Module
-	manufacturer = OKB-1
+	manufacturer = #roMfrOKB1
 	description = The Voskhod SA Descent Module was a re-purposed version of the Vostok SA. It was retrofitted to allow for an Airlock attachment for EVA and even to fit 3 cosmonauts. However, with 3 cosmonauts, there was not enough room to wear pressure suits. The SA stands for Spuskaemiy Apparat (Descent System) and was designed as a ballistic reentry capsule. [Diameter 2.3 m]
 	tags = soviet, capsule, crew, descent, voskhod
 
@@ -55,7 +61,7 @@ PART
 	//	Thermo, Durability
 	//	============================================================================
 
-	mass = 1.809 // + 450kg ablator + supplied = 2457kg
+	mass = 1.186	//2900 kg wet. 484 kg ablator, 670 kg batteries, crew 300 kg, 113 kg supplies, 40 kg tanks, 21 kg antenna, 70 kg chute, ??? kg landing motor. 
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.2
@@ -65,7 +71,7 @@ PART
 	breakingTorque = 250
 	fuelCrossFeed = True
 
-	heatShieldDiameter = 4.243 // really 2.3, but tweak to apply more ablator
+	heatShieldDiameter = 4.4 // really 2.3, but tweak to apply more ablator
 	heatShieldTag = Mercury
 	resetHeatShieldAblator = true
 	resetHeatShieldMass = false
@@ -102,15 +108,54 @@ PART
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 632.28
-		type = ServiceModule
-		basemass = -1
+		volume = 450
+		type = SM-II
+		basemass = 1.186
 		TANK
 		{
 			name = ElectricCharge
-			amount = 1000
-			maxAmount = 1000
-		}	
+			amount = 232000
+			maxAmount = 232000
+		}
+	}
+
+	//The SRM is attached to the parachute cord, but that's harder to set up
+	//also makes staging harder
+	MODULE
+	{
+		name = ModuleEnginesRF
+		thrustVectorTransformName = newThrustTransform
+		EngineType = SolidBooster
+		throttleLocked = True
+		exhaustDamage = True
+		ignitionThreshold = 0.1
+		minThrust = 16.7
+		maxThrust = 16.7
+		heatProduction = 400
+		useEngineResponseTime = True
+		engineAccelerationSpeed = 2.0
+		allowShutdown = False
+		fxOffset = 0, 0, 0.35
+		staged = True
+		stagingEnabled = True
+		PROPELLANT
+		{
+			name = SolidFuel
+			ratio = 1.0
+			DrawGauge = True
+		}
+		atmosphereCurve
+		{
+			key = 0 250
+			key = 1 230
+		}
+	}
+
+	RESOURCE
+	{
+		name = SolidFuel
+		amount = 2.8
+		maxAmount = 2.8
 	}
 
 	MODULE
@@ -286,13 +331,4 @@ PART
 			DumpExcess = False
 		}
 	}
-}
-
-//	================================================================================
-//	Final Pass to Make Sure TAC does not add extra resources
-//	================================================================================
-
-@PART[ROC-VoskhodCapsule]:LAST[ROCapsules]
-{
-	!RESOURCE:HAS[~name[Ablator],~name[CharredAblator]],*{}
 }

--- a/GameData/ROCapsules/PartConfigs/Vostok/VoskhodRetroBooster.cfg
+++ b/GameData/ROCapsules/PartConfigs/Vostok/VoskhodRetroBooster.cfg
@@ -32,7 +32,7 @@ PART
 	category = Engine
 	subcategory = 0
 	title = Voskhod Retro Package
-	manufacturer = OKB-1
+	manufacturer = #roMfrOKB1
 	description = Voskhod backup retro unit. Attach above the Voskhod Capsule on top of the Voskhod Retro Decoupler.
 	tags = soviet, retro, booster, voskhod
 

--- a/GameData/ROCapsules/PartConfigs/Vostok/VoskhodRetroDecoupler.cfg
+++ b/GameData/ROCapsules/PartConfigs/Vostok/VoskhodRetroDecoupler.cfg
@@ -36,7 +36,7 @@ PART
 	category = Coupling
 	subcategory = 0
 	title = Voskhod Retro Decoupler
-	manufacturer = OKB-1
+	manufacturer = #roMfrOKB1
 	description = Place this above the Descent Module to decoupler the additional retro booster.
 	tags = soviet, decoupler, decouple, voskhod
 

--- a/GameData/ROCapsules/PartConfigs/Vostok/VostokCapsule.cfg
+++ b/GameData/ROCapsules/PartConfigs/Vostok/VostokCapsule.cfg
@@ -62,7 +62,7 @@ PART
 	//	Thermo, Durability
 	//	============================================================================
 
-	mass = 0.967 //2460 kg wet. 450kg ablator, 670 kg batteries, crew+chute 129 kg, 113 kg supplies, 40 kg tanks, 21 kg antenna, 70 kg chute. 
+	mass = 0.933 //2460 kg wet. 484 kg ablator, 670 kg batteries, crew+chute 129 kg, 113 kg supplies, 40 kg tanks, 21 kg antenna, 70 kg chute. 
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.2
@@ -72,7 +72,7 @@ PART
 	breakingTorque = 250
 	fuelCrossFeed = True
 
-	heatShieldDiameter = 4.243 // really 2.3, but tweak to apply more ablator
+	heatShieldDiameter = 4.4 // really 2.3, but tweak to apply more ablator
 	heatShieldTag = Mercury
 	resetHeatShieldAblator = true
 	resetHeatShieldMass = false
@@ -109,9 +109,9 @@ PART
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 450
+		volume = 600
 		type = SM-II
-		basemass = 0.967
+		basemass = 0.933
 		TANK
 		{
 			name = ElectricCharge

--- a/GameData/ROCapsules/PartConfigs/Vostok/VostokCapsule.cfg
+++ b/GameData/ROCapsules/PartConfigs/Vostok/VostokCapsule.cfg
@@ -1,3 +1,12 @@
+	//sources:
+	// https://en.wikipedia.org/wiki/Vostok_(spacecraft)	honestly pretty good, and other sources are bad
+	// http://www.b14643.de/Spacerockets/Specials/KB-Isayev_KDUs/index.htm
+	// http://www.astronaut.ru/bookcase/article/article130.htm?reload_coolmenus
+	// http://www.buran.ru/htm/gud%2018.htm
+	// https://ru.wikipedia.org/wiki/%D0%92%D0%BE%D1%81%D1%82%D0%BE%D0%BA_(%D0%BA%D0%BE%D1%81%D0%BC%D0%B8%D1%87%D0%B5%D1%81%D0%BA%D0%B8%D0%B9_%D0%BA%D0%BE%D1%80%D0%B0%D0%B1%D0%BB%D1%8C)
+	// http://www.astronautix.com/s/s54.html
+	// http://www.lpre.de/kbhm/index.htm
+
 PART
 {
 	name = ROC-VostokCapsule
@@ -40,7 +49,7 @@ PART
 	category = Pods
 	subcategory = 0
 	title = Vostok Descent Module
-	manufacturer = OKB-1
+	manufacturer = #roMfrOKB1
 	description = The Vostok SA Descent Module was the first spacecraft to carry humans into space when Yuri Gagarin flew on April 12, 1961. The SA stands for Spuskaemiy Apparat (Descent System) and was designed as a ballistic reentry capsule. [Diameter 2.3 m]
 	tags = vostok, gagarin, soviet, capsule, crew, descent
 
@@ -53,7 +62,7 @@ PART
 	//	Thermo, Durability
 	//	============================================================================
 
-	mass = 1.809 // + 450kg ablator
+	mass = 0.967 //2460 kg wet. 450kg ablator, 670 kg batteries, crew+chute 129 kg, 113 kg supplies, 40 kg tanks, 21 kg antenna, 70 kg chute. 
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.2
@@ -100,14 +109,14 @@ PART
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 189.59
-		type = ServiceModule
-		basemass = -1
+		volume = 450
+		type = SM-II
+		basemass = 0.967
 		TANK
 		{
 			name = ElectricCharge
-			amount = 1000
-			maxAmount = 1000
+			amount = 232000
+			maxAmount = 232000
 		}
 	}
 

--- a/GameData/ROCapsules/PartConfigs/Vostok/VostokDecoupler.cfg
+++ b/GameData/ROCapsules/PartConfigs/Vostok/VostokDecoupler.cfg
@@ -36,7 +36,7 @@ PART
 	category = Coupling
 	subcategory = 0
 	title = Vostok/Voskhod Decoupler
-	manufacturer = OKB-1
+	manufacturer = #roMfrOKB1
 	description = Place this between the Descent Module and the Service Module to decouple the Capsule for reentry.
 	tags = vostok, gagarin, soviet, decoupler, decouple, voskhod
 

--- a/GameData/ROCapsules/PartConfigs/Vostok/VostokParachute.cfg
+++ b/GameData/ROCapsules/PartConfigs/Vostok/VostokParachute.cfg
@@ -32,7 +32,7 @@ PART
 	category = Utility
 	subcategory = 0
 	title = Vostok/Voskhod Parachute
-	manufacturer = OKB-1
+	manufacturer = #roMfrOKB1
 	description = When Yuri Gagarin returned to Earth after the first maiden spaceflight, he ejected from the capsule and parachuted to the ground. It was not until later versions of the capsule was the Parachute added. Connect this to the open part of the capsule
 	tags = vostok, gagarin, soviet, para, parachute, voskhod
 

--- a/GameData/ROCapsules/PartConfigs/Vostok/VostokService.cfg
+++ b/GameData/ROCapsules/PartConfigs/Vostok/VostokService.cfg
@@ -114,7 +114,7 @@ PART
 				transformName = RCSthruster
 				emission = 0.0 0.0
 				emission = 0.1 0.0
-				emission = 1.0 1.0
+				emission = 1.0 0.2
 				speed = 0.0 0.8
 				speed = 1.0 1.0
 				localRotation = -90, 0, 0

--- a/GameData/ROCapsules/PartConfigs/Vostok/VostokService.cfg
+++ b/GameData/ROCapsules/PartConfigs/Vostok/VostokService.cfg
@@ -33,9 +33,9 @@ PART
 	category = Control
 	subcategory = 0
 	title = Vostok/Voskhod Service Module
-	manufacturer = OKB-1
+	manufacturer = #roMfrOKB1
 	description = A service module with batteries a simple engine AK20/Tonka250 engine that has only 1 ignition. This is the same service module that you use for Vostok and Voskhod. Attach the Decoupler to the Descent Module first and attach this to the bottom of the Descent Module.
-	tags = vostok, gagarin, soviet, service, module, voskhod
+	tags = vostok, gagarin, soviet, service, module, voskhod, zenit
 
 	bulkheadProfiles = size2
 
@@ -43,7 +43,7 @@ PART
 	//	Thermo, Durability
 	//	============================================================================
 
-	mass = 1.924
+	mass = 1.615 //2270 kg wet. 275 kg fuel, 20 kg nitrogen, 250 kg batteries?, 64 kg tanks, 25 kg decoupler, 21 kg antenna, 1615 kg dry?
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.2
@@ -93,6 +93,33 @@ PART
 				localRotation = -90, 0, 0
 			}
 		}
+		running2
+		{
+			AUDIO_MULTI_POOL
+			{
+				channel = Ship
+				transformName = RCSthruster
+				clip = sound_rocket_mini
+				volume = 0.0 0.0
+				volume = 0.02 0.1
+				volume = 0.5 0.1
+				volume = 1.0 0.1
+				pitch = 0.0 0.75
+				pitch = 1.0 1.5
+				loop = true
+			}
+			MODEL_MULTI_PARTICLE
+			{
+				modelName = Squad/FX/Monoprop_small
+				transformName = RCSthruster
+				emission = 0.0 0.0
+				emission = 0.1 0.0
+				emission = 1.0 1.0
+				speed = 0.0 0.8
+				speed = 1.0 1.0
+				localRotation = -90, 0, 0
+			}
+		}
 	}
 
 	//	============================================================================
@@ -106,7 +133,7 @@ PART
 		RESOURCE
 		{
 			name = ElectricCharge
-			rate = 0.30
+			rate = 0.20		//0.20 kW average
 		}
 	}
 
@@ -140,16 +167,17 @@ PART
 			minThrust = 15.83
 			maxThrust = 15.83
 			heatProduction = 100
+			ignitions = 1	//only 1 start provided
 			PROPELLANT
 			{
 				name = AK20
-				ratio = 0.636
+				ratio = 0.6360
 				DrawGauge = True
 			}
 			PROPELLANT
 			{
 				name = Tonka250
-				ratio = 0.364
+				ratio = 0.3640
 			}
 			atmosphereCurve
 			{
@@ -159,14 +187,41 @@ PART
 		}
 	}
 
+	//Vostok had two RCS systems. Deorbit orientation thrusters ran off main engine gas generator
+	//On-orbit attitude control was provided by cold-gas nitrogen thrusters
 	MODULE
 	{
 		name = ModuleRCSFX
 		stagingEnabled = True
 		thrusterTransformName = RCSthruster
-		thrusterPower = 0.05
+		thrusterPower = 0.25	//guess
 		resourceFlowMode = STAGE_PRIORITY_FLOW
 		runningEffectName = running1
+		PROPELLANT
+		{
+			name = AK20
+			ratio = 0.6360
+			DrawGauge = True
+		}
+		PROPELLANT
+		{
+			name = Tonka250
+			ratio = 0.3640
+		}
+		atmosphereCurve
+		{
+			key = 0 200
+			key = 1 100
+		}
+	}
+	MODULE
+	{
+		name = ModuleRCSFX
+		stagingEnabled = True
+		thrusterTransformName = RCSthruster
+		thrusterPower = 0.010	//16x5N. We only have 6, so we're gonna assume they're mostly doubled up
+		resourceFlowMode = STAGE_PRIORITY_FLOW
+		runningEffectName = running2
 		PROPELLANT
 		{
 			ratio = 1.0
@@ -182,10 +237,10 @@ PART
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 378.98
-		type = Fuselage
-		basemass = -1
-		TANK
+		volume = 500
+		type = SM-II
+		basemass = 1.615
+		TANK	//275 kg main engine fuel
 		{
 			name = AK20
 			amount = 135.222
@@ -200,10 +255,10 @@ PART
 		TANK
 		{
 			name = ElectricCharge
-			amount = 86400
+			amount = 86400		//24 kWh
 			maxAmount = 86400
 		}
-		TANK
+		TANK	//20 kg nitrogen
 		{
 			name = Nitrogen
 			amount = 15990

--- a/GameData/ROCapsules/PartConfigs/Vostok/Waterfall_Support_Vostok.cfg
+++ b/GameData/ROCapsules/PartConfigs/Vostok/Waterfall_Support_Vostok.cfg
@@ -57,5 +57,21 @@
                 loop = true
             }
         }
+        running2
+        {
+            AUDIO_MULTI_POOL
+            {
+                channel = Ship
+                transformName = RCSthruster
+                clip = sound_rocket_mini
+                volume = 0.0 0.0
+                volume = 0.02 0.1
+                volume = 0.5 0.1
+                volume = 1.0 0.1
+                pitch = 0.0 0.75
+                pitch = 1.0 1.5
+                loop = true
+            }
+        }
     }
 }

--- a/GameData/ROCapsules/PartConfigs/Vostok/ZenitCapsule.cfg
+++ b/GameData/ROCapsules/PartConfigs/Vostok/ZenitCapsule.cfg
@@ -35,7 +35,7 @@ PART
 	category = Pods
 	subcategory = 0
 	title = Zenit Descent Module (Improved Film Camera)
-	manufacturer = OKB-1
+	manufacturer = #roMfrOKB1
 	description = The Zenit Descent Module was developed in parallel with the Vostok Descent Module, for photoreconnaissance use. Placing the camera equipment in a pressurized capsule made development much easier, and the cameras and film could be recovered together, reducing cost. Historically used as a spy satellite, but for our peaceful RP-1 purposes, these represent the earliest weather satellite photos.
 	tags = vostok zenit soviet capsule descent science photo photographs film camera corona spy sats dmagic
 
@@ -47,7 +47,7 @@ PART
 	//	Thermo, Durability
 	//	============================================================================
 
-	mass = 1.809 // + 450kg ablator. Roughly the same mass as Vostok
+	mass = 0.995 //2340 kg wet?. 484 kg ablator, 670 kg batteries, 21 kg antenna, 70 kg chute, 100 kg film?.
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.2
@@ -57,7 +57,7 @@ PART
 	breakingTorque = 250
 	fuelCrossFeed = True
 
-	heatShieldDiameter = 4.243 // really 2.3, but tweak to apply more ablator
+	heatShieldDiameter = 4.4 // really 2.3, but tweak to apply more ablator
 	heatShieldTag = Mercury
 	resetHeatShieldAblator = true
 	resetHeatShieldMass = false
@@ -82,14 +82,14 @@ PART
 	MODULE
 	{
 		name = ModuleFuelTanks
-		volume = 189.59
-		type = ServiceModule
-		basemass = -1
+		volume = 450
+		type = SM-II
+		basemass = 0.995
 		TANK
 		{
 			name = ElectricCharge
-			amount = 100000
-			maxAmount = 100000
+			amount = 232000
+			maxAmount = 232000
 		}
 	}
 


### PR DESCRIPTION
A more limited overhaul, due to lack of good sources. Changes include:

- Vostok, Voskhod, and Zenit mass brought into line when loaded with the correct crew, cargo, resources, and equipment
- Vostok, Voskhod, and Zenit now use SM-II tankage instead of massless SM tankage
- Vostok, Voskhod, and Zenit ablator levels increased to better survive worst-case reentry profile (from natural decay and/or backup SRM)
- Vostok, Voskhod, and Zenit battery capacity increased to probably historical levels
- Voskhod has been given a landing braking motor to allow for safer landings
- Vostok Service Module now uses SM-II tankage instead of massless SM tankage
- Vostok Service Module now has Gas Generator biprop RCS
- Vostok Service Module cold gas RCS thrust reduced to real values
- TDU-1/S5.4 reduced to one ignition only

resolves https://github.com/KSP-RO/ROCapsules/issues/139