### PR TITLE
Put mercury posigrade motor isp the same as retrograde motor

### DIFF
--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryPosigrade.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryPosigrade.cfg
@@ -101,8 +101,8 @@ PART
 
 			atmosphereCurve
 			{
-				key = 0 107.04
-				key = 1 107.04
+				key = 0 206
+				key = 1 85
 			}
 		}
 	}

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryPosigrade.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryPosigrade.cfg
@@ -25,7 +25,7 @@ PART
 	manufacturer = Thiokol
 	description = This tiny solid rocket motor was originally used to push a Mercury away from its Atlas booster. We're sure you'll think of even more uses for it.
 	attachRules = 0,1,0,0,0
-	mass = 0.000508		//1.12 lbs
+	mass = 0.00143		//3.15 lbs
 	dragModelType = default
 	maximum_drag  = 0.20
 	minimum_drag = 0.15
@@ -62,18 +62,20 @@ PART
 		%ignitions = 1
 	}
 
+	//Should provide 15 ft/s (~4.5 m/s) to Mercury spacecraft
+	//This also leaves us with a mass ratio <1, which seems reasonable for an early SRM of this size.
 	MODULE
 	{
 		name = ModuleFuelTanks
 		type = PSPC
-		volume = 1.103
+		volume = 0.573
 		basemass = -1
 
 		TANK
 		{
 			name = PSPC		//~4.23 lbs propellant
-			amount = 1.103 
-			maxAmount =	 1.103
+			amount = 0.573
+			maxAmount = 0.573
 		}
 	}
 

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryPosigrade.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryPosigrade.cfg
@@ -101,8 +101,8 @@ PART
 
 			atmosphereCurve
 			{
-				key = 0 206
-				key = 1 85
+				key = 0 206 //No info found on posigrade motors, so I used the retrograde motor isp sourced below
+				key = 1 85 //https://www.sciencedirect.com/science/article/pii/S1000936121003319
 			}
 		}
 	}

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryPosigrade.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryPosigrade.cfg
@@ -73,7 +73,7 @@ PART
 
 		TANK
 		{
-			name = PSPC		//~4.23 lbs propellant
+			name = PSPC		//~2.20 lbs propellant
 			amount = 0.573
 			maxAmount = 0.573
 		}

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryRetropack.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryRetropack.cfg
@@ -8,7 +8,7 @@ PART
 	RSSROConfig = true
 
 	//	================================================================================
-	//Source for all Mercury Masses: http://www.alternatewars.com/BBOW/Space/JSC-26098_Design_Mass_Properties_II.pdf
+	//Source for all Mercury Masses: https://web.archive.org/web/20220911044835/http://www.alternatewars.com/BBOW/Space/JSC-26098_Design_Mass_Properties_II.pdf
 	//	================================================================================
 	//Mercury Retro Module dry mass breakdown:
 	//	================================================================================

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryRetropack.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryRetropack.cfg
@@ -65,7 +65,7 @@ PART
 	//	Retro: 20.63 lbs (9.36 kg) (x3)
 	//		Dry Mass: 20.63 lbs (x3)
 	//	================================================================================
-	//	Posigrade: 3.15 lbs (0.51 kg) (x3) (removing 2.20 lbs propellant)
+	//	Posigrade: 3.15 lbs (1.43 kg) (x3) (removing 2.20 lbs propellant)
 	//		Dry Mass: 3.15 lbs (x3)
 	//	================================================================================
 	//INERT MASS: 125.35 lbs (56.86 kg)

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryRetropack.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryRetropack.cfg
@@ -8,7 +8,7 @@ PART
 	RSSROConfig = true
 
 	//	================================================================================
-	//Source for all Mercury Masses: https://web.archive.org/web/20220911044835/http://www.alternatewars.com/BBOW/Space/JSC-26098_Design_Mass_Properties_II.pdf
+	//Source for all Mercury Masses: http://www.alternatewars.com/BBOW/Space/JSC-26098_Design_Mass_Properties_II.pdf
 	//	================================================================================
 	//Mercury Retro Module dry mass breakdown:
 	//	================================================================================
@@ -65,8 +65,8 @@ PART
 	//	Retro: 20.63 lbs (9.36 kg) (x3)
 	//		Dry Mass: 20.63 lbs (x3)
 	//	================================================================================
-	//	Posigrade: 1.12 lbs (0.51 kg) (x3) (removing 4.23 lbs propellant)
-	//		Dry Mass: 1.12 lbs (x3)
+	//	Posigrade: 3.15 lbs (0.51 kg) (x3) (removing 2.20 lbs propellant)
+	//		Dry Mass: 3.15 lbs (x3)
 	//	================================================================================
 	//INERT MASS: 125.35 lbs (56.86 kg)
 
@@ -76,9 +76,9 @@ PART
 	//Retro: 12.57 L (x3)
 	//	Propellant: 12.57 L
 	//		PSPC: 12.57 L
-	//Posigrade: 1.103 L (x3)
-	//	Propellant: 1.103 L
-	//		PSPC: 1.103 L
+	//Posigrade: 0.573 L (x3)
+	//	Propellant: 0.573 L
+	//		PSPC: 0.573 L
 
 	//	================================================================================
 	//Tank Mass Compensation


### PR DESCRIPTION
I have no idea where the original values of the retrograde and posigrade motors' specific impulse (the very specific value of 107.04) came from, but in my opinion it seems quite unrealistic. If I recall correctly, even helium has a higher specific impulse than 107. Perhaps a value of around 190 is possible due to the very small engine bell that the posigrade motors used, but unless someone finds a isp value for the posigrade motors I thinking keeping it at the same as the retrograde motors is fine.

Please do tell me if you do happen to find an isp value for the posigrade motors, I looked for several hours and I could not find anything.