### PR TITLE
Update name in ROCapsules.netkan

### DIFF
--- a/ROCapsules.netkan
+++ b/ROCapsules.netkan
@@ -1,47 +1,42 @@
-{
-    "spec_version"   : "v1.10",
-    "$kref"          : "#/ckan/github/KSP-RO/ROCapsules",
-    "$vref"          : "#/ckan/ksp-avc",
-    "x_netkan_force_v": true,
-    "name"           : "ROCapsules",
-    "identifier"     : "ROCapsules",
-    "abstract"       : "ROCapsules is a mod that takes the best versions of capsules available and uses them as the in-game models for Realism Overhaul parts.",
-    "author"         : [ "pap1723", "KSP-RO" ],
-    "license"        : "CC-BY-SA",
-    "release_status" : "stable",
-    "resources" : {
-        "bugtracker"   : "https://github.com/KSP-RO/ROCapsules/issues",
-        "repository"   : "https://github.com/KSP-RO/ROCapsules",
-        "homepage"     : "https://discordapp.com/invite/ZGbR6nv"
-    },
-    "depends" : [
-        { "name" : "ModuleManager" },
-        { "name" : "RealismOverhaul" },
-        { "name" : "TexturesUnlimited" },
-        { "name" : "ROLib" },
-        { "name" : "B9PartSwitch" },
-        { "name" : "DepthMask" },
-        { "name" : "KSPWheel" },
-		{ "name" : "StagedAnimation" },
-        { "name" : "BDAnimationModules" }
-    ],
-    "recommends" : [
-        { "name" : "ROEngines" },
-        { "name" : "ROTanks" },
-        { "name" : "ProceduralFairings" },
-        { "name" : "ProceduralParts" },
-        { "name" : "MechJeb2" },
-        { "name" : "RealSolarSystem" },
-        { "name" : "KSCSwitcher" },
-        { "name" : "RP-0" }
-    ],
-    "conflicts" : [
-        { "name" : "TweakableEverything" }
-    ],
-    "install" : [
-        {
-            "file"       : "GameData/ROCapsules",
-            "install_to" : "GameData"
-        }
-    ]
-}
+spec_version: v1.10
+$kref: '#/ckan/github/KSP-RO/ROCapsules'
+$vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
+name: RO Capsules
+identifier: ROCapsules
+abstract: >-
+  Takes the best versions of capsules available and uses them as the in-game
+  models for Realism Overhaul parts.
+author:
+  - pap1723
+  - KSP-RO
+license: CC-BY-SA
+release_status: stable
+resources:
+  bugtracker: https://github.com/KSP-RO/ROCapsules/issues
+  repository: https://github.com/KSP-RO/ROCapsules
+  homepage: https://discordapp.com/invite/ZGbR6nv
+depends:
+  - name: ModuleManager
+  - name: RealismOverhaul
+  - name: TexturesUnlimited
+  - name: ROLib
+  - name: B9PartSwitch
+  - name: DepthMask
+  - name: KSPWheel
+  - name: StagedAnimation
+  - name: BDAnimationModules
+recommends:
+  - name: ROEngines
+  - name: ROTanks
+  - name: ProceduralFairings
+  - name: ProceduralParts
+  - name: MechJeb2
+  - name: RealSolarSystem
+  - name: KSCSwitcher
+  - name: RP-0
+conflicts:
+  - name: TweakableEverything
+install:
+  - file: GameData/ROCapsules
+    install_to: GameData


### PR DESCRIPTION
Hi @siimav,

I noticed while investigating KSP-CKAN/CKAN#3911 that 66% of the "ROSomething" mods have a space after "RO":

![image](https://github.com/KSP-RO/ROCapsules/assets/1559108/95269081-4002-4b6b-89b2-0cf24eed70b9)

Now ROCapsules will as well.

I'll send another PR after this for the heat shields.

Cheers!
