### PR TITLE
Correct LM dry mass (also adjust fuel load)

### DIFF
--- a/GameData/ROCapsules/PartConfigs/LEMBDB/LEMAscentBDB.cfg
+++ b/GameData/ROCapsules/PartConfigs/LEMBDB/LEMAscentBDB.cfg
@@ -293,13 +293,13 @@ PART
 	//Ultimate Part Resource Assignments:
 	//	================================================================================
 	//LM Ascent Module:
-	//	APS Propellant: 2384.80 L
-	//		AZ50: 1113.7 L
-	//		NTO: 1106.1 L
+	//	APS Propellant: 2199.40 L
+	//		AZ50: 1015.1 L
+	//		NTO: 1019.3 L
 	//		Helium: 33000 L (/200)
-	//	RCS Propellant: 218.46 L
-	//		AZ50: 84.4 L
-	//		NTO: 107.4 L
+	//	RCS Propellant: 220.27 L (RCS propellant loaded at 1.94:1 in expectation of crossfeed to APS)
+	//		AZ50: 87.3 L
+	//		NTO: 106.3 L
 	//		Helium: 5333 L (/200)
 	//	LM Ascent LS: 132.85 L
 	//		Water (Cooling): 11.16 L
@@ -518,7 +518,7 @@ PART
 	{
 		name = ModuleFuelTanks
 		type = SM-IV
-		volume = 2732.935
+		volume = 2549.345
 		basemass = 1.53975
 
 		//	Two batteries ~16.6 kWh (28 V @ 296 Ah each).
@@ -533,17 +533,17 @@ PART
 		//Propellant: 5746.2 lbs
 		TANK
 		{
-			// 167.0 lbs RCS + 2,014.1 lbs main
+			// 173.3 lbs RCS + 2,014.1 lbs main
 			name = Aerozine50
-			amount = 1099.26
-			maxAmount = 1099.26
+			amount = 1102.4
+			maxAmount = 1102.4
 		}
 		TANK
 		{
-			// 342.5 lbs RCS + 3,222.6 lbs main
+			// 336.2 lbs RCS + 3,222.6 lbs main
 			name = MON1
-			amount = 1127.61
-			maxAmount = 1127.61
+			amount = 1125.6
+			maxAmount = 1125.6
 		}
 		TANK
 		{
@@ -661,12 +661,12 @@ PART
 {
 	@description ^= :$: Supports a crew of two for up to 3 days of active operations.
 
-	@mass -= 0.8502		//-72.27 kg (LS Resources) - 12.75 kg (LS Tanks)
+	@mass -= 0.08502		//-72.27 kg (LS Resources) - 12.75 kg (LS Tanks)
 
 	@MODULE[ModuleFuelTanks]
 	{
 		@volume += 132.85
-		@basemass -= 0.8502
+		@basemass -= 0.08502
 
 		TANK
 		{


### PR DESCRIPTION
Add a misplaced zero so the correct amount of dry mass is subtracted from the LM for life support resources. Also adjust fuel ratio a bit to improve performance.

This results in a significant increase in LM ascent stage dry mass.

Needs https://github.com/KSP-RO/ROKerbalism/pull/156