### PR TITLE
Require SXT

### DIFF
--- a/ROCapsules.netkan
+++ b/ROCapsules.netkan
@@ -32,6 +32,8 @@ depends:
     suppress_recommendations: true
   - name: BDAnimationModules
     suppress_recommendations: true
+  - name: SXTContinued
+    suppress_recommendations: true
 recommends:
   - name: ROEngines
   - name: ROTanks


### PR DESCRIPTION
SXT is a hard dependency of ROCapsules last time I checked, will cause some texture errors without it.