### PR TITLE
Remove magnets from ports with accurate colliders

### DIFF
--- a/GameData/ROCapsules/PartConfigs/APAS/APAS_Activev2.cfg
+++ b/GameData/ROCapsules/PartConfigs/APAS/APAS_Activev2.cfg
@@ -61,11 +61,11 @@ PART
 		nodeType = APAS8995
 		gendered = false
 		genderFemale = false
-		acquireForce = 0.5 // 2
+		acquireForce = 0 //0.5
 		acquireMinFwdDot = 0.8 // 0.7
 		acquireminRollDot = -3.40282347E+38
 		acquireRange = 0.25 // 0.5
-		acquireTorque = 0.5 // 2.0
+		acquireTorque = 0 // 0.5
 		captureMaxRvel = 0.1 // 0.3
 		captureMinFwdDot = 0.998
 		captureMinRollDot = -3.40282347E+38

--- a/GameData/ROCapsules/PartConfigs/APAS/APAS_Passivev2.cfg
+++ b/GameData/ROCapsules/PartConfigs/APAS/APAS_Passivev2.cfg
@@ -62,11 +62,11 @@ PART
 		nodeType = APAS8995
 		gendered = false
 		genderFemale = false
-		acquireForce = 0.5 // 2
+		acquireForce = 0 //0.5
 		acquireMinFwdDot = 0.8 // 0.7
 		acquireminRollDot = -3.40282347E+38
 		acquireRange = 0.25 // 0.5
-		acquireTorque = 0.5 // 2.0
+		acquireTorque = 0 // 0.5
 		captureMaxRvel = 0.1 // 0.3
 		captureMinFwdDot = 0.998
 		captureMinRollDot = -3.40282347E+38

--- a/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloCADSActive.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloCADSActive.cfg
@@ -55,11 +55,11 @@ PART
 		nodeType = CADS
 		gendered = false
 		genderFemale = false
-		acquireForce = 0.5 // 2
+		acquireForce = 0 //0.5
 		acquireMinFwdDot = 0.8 // 0.7
 		acquireminRollDot = -3.40282347E+38
 		acquireRange = 0.25 // 0.5
-		acquireTorque = 0.5 // 2.0
+		acquireTorque = 0 // 0.5
 		captureMaxRvel = 0.1 // 0.3
 		captureMinFwdDot = 0.998
 		captureMinRollDot = -3.40282347E+38

--- a/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloCADSPassive.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloCADSPassive.cfg
@@ -55,11 +55,11 @@ PART
 		nodeType = CADS
 		gendered = false
 		genderFemale = false
-		acquireForce = 0.5 // 2
+		acquireForce = 0 //0.5
 		acquireMinFwdDot = 0.8 // 0.7
 		acquireminRollDot = -3.40282347E+38
 		acquireRange = 0.25 // 0.5
-		acquireTorque = 0.5 // 2.0
+		acquireTorque = 0 // 0.5
 		captureMaxRvel = 0.1 // 0.3
 		captureMinFwdDot = 0.998
 		captureMinRollDot = -3.40282347E+38

--- a/GameData/ROCapsules/PartConfigs/ApolloBDB/ASTP/ApolloAPAS75BDB.cfg
+++ b/GameData/ROCapsules/PartConfigs/ApolloBDB/ASTP/ApolloAPAS75BDB.cfg
@@ -91,6 +91,17 @@ PART
 		referenceAttachNode = top
 		nodeType = APAS75
 		gendered = False
+		acquireForce = 0 //0.5
+		acquireMinFwdDot = 0.8 // 0.7
+		acquireminRollDot = -3.40282347E+38
+		acquireRange = 0.25 // 0.5
+		acquireTorque = 0 // 0.5
+		captureMaxRvel = 0.1 // 0.3
+		captureMinFwdDot = 0.998
+		captureMinRollDot = -3.40282347E+38
+		captureRange = 0.05 // 0.06
+		minDistanceToReEngage = 0.25 // 1.0
+		undockEjectionForce = 0.1 // 10
 	}
 
 	MODULE:NEEDS[ConnectedLivingSpace]

--- a/GameData/ROCapsules/PartConfigs/ApolloBDB/ApolloProbeDockPortBDB.cfg
+++ b/GameData/ROCapsules/PartConfigs/ApolloBDB/ApolloProbeDockPortBDB.cfg
@@ -96,17 +96,17 @@ PART
 		nodeType = Apollo
 		gendered = True
 		genderFemale = False
-		acquireForce = 0.5
-		acquireMinFwdDot = 0.8
+		acquireForce = 0 //0.5
+		acquireMinFwdDot = 0.8 // 0.7
 		acquireminRollDot = -3.40282347E+38
-		acquireRange = 0.25
-		acquireTorque = 0.5
-		captureMaxRvel = 0.1
+		acquireRange = 0.25 // 0.5
+		acquireTorque = 0 // 0.5
+		captureMaxRvel = 0.1 // 0.3
 		captureMinFwdDot = 0.998
 		captureMinRollDot = -3.40282347E+38
-		captureRange = 0.05
-		minDistanceToReEngage = 0.25
-		undockEjectionForce = 0.1
+		captureRange = 0.05 // 0.06
+		minDistanceToReEngage = 0.25 // 1.0
+		undockEjectionForce = 0.1 // 10
 	}
 	
 	MODULE:NEEDS[ConnectedLivingSpace]

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/AgenaPort.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/AgenaPort.cfg
@@ -81,11 +81,11 @@ PART
 		nodeType = GeminiAgena
 		gendered = True
 		genderFemale = True
-		acquireForce = 0.5 // 2
+		acquireForce = 0 //0.5
 		acquireMinFwdDot = 0.8 // 0.7
 		acquireminRollDot = -3.40282347E+38
 		acquireRange = 0.25 // 0.5
-		acquireTorque = 0.5 // 2.0
+		acquireTorque = 0 // 0.5
 		captureMaxRvel = 0.1 // 0.3
 		captureMinFwdDot = 0.998
 		captureMinRollDot = -3.40282347E+38

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiNosecone.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiNosecone.cfg
@@ -67,11 +67,11 @@ PART
 		nodeType = GeminiAgena
 		gendered = True
 		genderFemale = False
-		acquireForce = 0.5 // 2
+		acquireForce = 0 //0.5
 		acquireMinFwdDot = 0.8 // 0.7
 		acquireminRollDot = -3.40282347E+38
 		acquireRange = 0.25 // 0.5
-		acquireTorque = 0.5 // 2.0
+		acquireTorque = 0 // 0.5
 		captureMaxRvel = 0.1 // 0.3
 		captureMinFwdDot = 0.998
 		captureMinRollDot = -3.40282347E+38

--- a/GameData/ROCapsules/PartConfigs/LEMBDB/ApolloDrogueDockPortBDB.cfg
+++ b/GameData/ROCapsules/PartConfigs/LEMBDB/ApolloDrogueDockPortBDB.cfg
@@ -75,17 +75,17 @@ PART
 		nodeType = Apollo
 		gendered = True
 		genderFemale = True
-		acquireForce = 0.5
-		acquireMinFwdDot = 0.8
+		acquireForce = 0 //0.5
+		acquireMinFwdDot = 0.8 // 0.7
 		acquireminRollDot = -3.40282347E+38
-		acquireRange = 0.25
-		acquireTorque = 0.5
-		captureMaxRvel = 0.1
+		acquireRange = 0.25 // 0.5
+		acquireTorque = 0 // 0.5
+		captureMaxRvel = 0.1 // 0.3
 		captureMinFwdDot = 0.998
 		captureMinRollDot = -3.40282347E+38
-		captureRange = 0.05
-		minDistanceToReEngage = 0.25
-		undockEjectionForce = 0.1
+		captureRange = 0.05 // 0.06
+		minDistanceToReEngage = 0.25 // 1.0
+		undockEjectionForce = 0.1 // 10
 	}
 
 	MODULE:NEEDS[ConnectedLivingSpace]


### PR DESCRIPTION
Remove the magic docking magnets from docking ports that have actually functional colliders. Tested, and everything is still relatively forgiving, part colliders are pretty slippery so it's easy to force everything into alignment as long as you're close.