### PR TITLE
Separate Mercury chute and minor QoL fixes

### DIFF
--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryCM.cfg
@@ -72,7 +72,7 @@ PART
 	//		Antenna: 27 lbs
 	//		Antenna Misc: 8 lbs
 	//	================================================================================
-	//RCS: 280 lbs
+	//RCS: 123 lbs
 	//	Structure: 36 lbs
 	//		Parachute Struct: 36 lbs
 	//	Propulsion: 52 lbs
@@ -80,9 +80,12 @@ PART
 	//		RCS Mounting: 11 lbs
 	//		RCS Insulation: 10 lbs
 	//		RCS Heat Sink: 10 lbs
-	//	Other: 192 lbs
-	//		Chutes: 157 lbs
+	//	Other: 35 lbs
 	//		Recovery Sys: 35 lbs
+	//	================================================================================
+	//Parachute: 157 lbs
+	//	Other: 157 lbs
+	//		Chutes: 157 lbs
 	//	================================================================================
 	//TOTAL DRY MASS: 2389 lbs (2393 - 4 lbs LiOH)
 	//	Structure: 377 lbs
@@ -142,8 +145,11 @@ PART
 	//	Nose Cap: 72 lbs (32.66 kg)
 	//		Dry Mass: 72 lbs
 	//	================================================================================
-	//	RCS: 280 lbs (127.01 kg)
-	//		Dry Mass: 280 lbs
+	//	RCS: 123 lbs (55.79 kg)
+	//		Dry Mass: 123 lbs
+	//	================================================================================
+	//	Parachute: 157 lbs (71.21 kg)
+	//		Dry Mass: 157 lbs
 	//	================================================================================
 	//INERT MASS: 2429 lbs (1101.78 kg)
 
@@ -236,7 +242,7 @@ PART
 	breakingForce = 250
 	breakingTorque = 250
 	vesselType = Ship
-	stagingIcon = COMMAND_POD
+	stagingIcon = RCS_MODULE
 	CrewCapacity = 1
 	bulkheadProfiles = size0, size1
 

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryParachute.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryParachute.cfg
@@ -1,0 +1,130 @@
+PART
+{
+	name = ROC-MercuryParachute
+	module = Part
+	author = CobaltWolf, capkirk
+
+	RSSROConfig = true
+
+	MODEL
+	{
+		model = ROCapsules/Assets/BDB/Mercury/bluedog_Mercury_Parachute
+		rotation = 0, 180, 0
+	}
+	rescaleFactor = 1.512
+
+	NODE
+	{
+		transform = parachute_Node
+		name = parachute
+		size = 0
+		method = FIXED_JOINT
+	}
+
+	buoyancyUseCubeNamed = PACKED
+	sound_parachute_open = activate
+	sound_parachute_single = deploy
+	TechRequired = start
+	entryCost = 0
+	cost = 1
+	category = Utility
+	subcategory = 0
+	title = Mercury-MASD Main Parachute
+	manufacturer = McDonnell Aircraft
+	description =  Main parachute for the Mercury capsule. Attach to the node in the recovery section.
+	attachRules = 1,0,1,1,0
+	mass = 0.05460		//71.21 kg, subtract 16.61 kgs added by realchute?
+	dragModelType = default
+	angularDrag = 3
+	crashTolerance = 12
+	stageOffset = 1
+	childStageOffset = 1
+	bulkheadProfiles = size0
+	bodyLiftMultiplier = 0
+
+	//Fiberglass over Titanium structure? (same as Gemini)
+	skinTempTag = Fiberglass
+	internalTempTag = Instruments
+
+	tags = mercury parachute
+
+	MODULE:NEEDS[!RealChute]
+	{
+		name = ModuleParachute
+		semiDeployedAnimation = semi_deploy
+		fullyDeployedAnimation = full_deploy
+		shieldedCanDeploy = true
+		invertCanopy = false
+		autoCutSpeed = 0.5
+		capName = Cap
+		canopyName = canopy
+		stowedDrag = 0.22
+		semiDeployedDrag = 1
+		fullyDeployedDrag = 300
+		minAirPressureToOpen = 0.04
+		clampMinAirPressure = 0.01
+		deployAltitude = 1000
+		deploymentSpeed = 0.12
+		semiDeploymentSpeed = 1 //0.5
+		chuteMaxTemp = 650
+	}
+
+	MODULE:NEEDS[RealChute]
+	{
+		name = RealChuteModule
+		caseMass = 0.05460
+		mustGoDown = True
+		spareChutes = 1
+		cutSpeed = 0.5
+		invertCanopy = false
+		reverseOrientation = true
+
+		PARACHUTE
+		{
+			parachuteName = canopy
+			capName = Cap
+			preDeploymentAnimation = semi_deploy
+			deploymentAnimation = full_deploy
+			material = Nylon
+			minIsPressure = False
+			minPressure = 0.01
+			preDeployedDiameter = 5
+			preDeploymentSpeed = 2
+			minDeployment = 3000
+			deployedDiameter = 19.2
+			deploymentSpeed = 6
+			deploymentAlt = 1000
+			cutAlt = 0
+			ignoreShielded = True	//because being inside the recovery section makes it think it's shielded
+		}
+	}
+
+	MODULE
+	{
+		name = ModuleDragModifier
+		dragCubeName = SEMIDEPLOYED
+		dragModifier = 4 //1.25
+	}
+
+	MODULE
+	{
+		name = ModuleDragModifier
+		dragCubeName = DEPLOYED
+		dragModifier = 45 //12
+	}
+}
+
+
+@PART[ROC-MercuryParachute]:AFTER[zzzRealismOverhaul]
+{
+	// RO forces all RealChuteModules to minDeploy 5000, deploy 1000,
+	// Get back our historical numbers
+	@MODULE[RealChuteModule]
+	{
+		@PARACHUTE
+		{
+			@minDeployment = 3000
+			@deploymentAlt = 1000
+		}
+	}
+}

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryParachute.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryParachute.cfg
@@ -29,7 +29,7 @@ PART
 	cost = 1
 	category = Utility
 	subcategory = 0
-	title = Mercury-MASD Main Parachute
+	title = Mercury M-ASD Main Parachute
 	manufacturer = McDonnell Aircraft
 	description =  Main parachute for the Mercury capsule. Attach to the node in the recovery section.
 	attachRules = 1,0,1,1,0

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryParachute.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryParachute.cfg
@@ -1,6 +1,6 @@
 PART
 {
-	name = ROC-MercuryParachute
+	name = ROC-MercuryParachuteBDB
 	module = Part
 	author = CobaltWolf, capkirk
 

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryRCS2.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryRCS2.cfg
@@ -1,11 +1,10 @@
 PART
 {
-	name = ROC-MercuryRCSBDB
+	name = ROC-MercuryRCS2BDB
 	module = Part
 	author = CobaltWolf, capkirk
 
 	RSSROConfig = true
-	RODeprecated = true
 
 	MODEL
 	{
@@ -13,11 +12,11 @@ PART
 		rotation = 0, 180, 0
 	}
 
-	MODEL
-	{
-		model = ROCapsules/Assets/BDB/Mercury/bluedog_Mercury_Parachute
-		rotation = 0, 180, 0
-	}
+	//MODEL
+	//{
+	//	model = ROCapsules/Assets/BDB/Mercury/bluedog_Mercury_Parachute
+	//	rotation = 0, 180, 0
+	//}
 
 	rescaleFactor = 1.512
 	node_stack_top = 0.0, 0.27984, 0.0, 0.0, 1.0, 0.0, 0
@@ -42,7 +41,7 @@ PART
 	manufacturer = McDonnell Aircraft
 	description = This part contains four way RCS thrusters to help orient the Mercury capsule and the main parachute.
 	attachRules = 1,0,1,1,0
-	mass = 0.1104		//127.01 kg, subtract 16.61 kgs added by realchute?
+	mass = 0.05579
 	dragModelType = default
 	maximum_drag = 0.01
 	minimum_drag = 0.01
@@ -52,7 +51,7 @@ PART
 	breakingTorque = 50
 	fuelCrossFeed = True
 	bodyLiftMultiplier = 0
-	bulkheadProfiles = size0
+	stagingIcon = RCS_MODULE
 
 	//Thermal Stuff
 	//Skin made of Rene 41 shingles (max temp 1144)
@@ -67,7 +66,7 @@ PART
 	internalTempTag = Instruments
 	skinInsulationTag = True
 
-	tags = mercury rcs parachute control
+	tags = mercury rcs control
 
 	EFFECTS
 	{
@@ -98,70 +97,6 @@ PART
 				localRotation = -90, 0, 0
 			}
 		}
-	}
-
-	MODULE:NEEDS[!RealChute]
-	{
-		name = ModuleParachute
-		semiDeployedAnimation = semi_deploy
-		fullyDeployedAnimation = full_deploy
-		shieldedCanDeploy = true
-		invertCanopy = false
-		autoCutSpeed = 0.5
-		capName = Cap
-		canopyName = canopy
-		stowedDrag = 0.22
-		semiDeployedDrag = 1
-		fullyDeployedDrag = 300
-		minAirPressureToOpen = 0.04
-		clampMinAirPressure = 0.01
-		deployAltitude = 1000
-		deploymentSpeed = 0.12
-		semiDeploymentSpeed = 1 //0.5
-		chuteMaxTemp = 650
-	}
-
-	MODULE:NEEDS[RealChute]
-	{
-		name = RealChuteModule
-		caseMass = 0.1104
-		mustGoDown = True
-		spareChutes = 1
-		cutSpeed = 0.5
-		invertCanopy = false
-		reverseOrientation = true
-
-		PARACHUTE
-		{
-			parachuteName = canopy
-			capName = Cap
-			preDeploymentAnimation = semi_deploy
-			deploymentAnimation = full_deploy
-			material = Nylon
-			minIsPressure = False
-			minPressure = 0.01
-			preDeployedDiameter = 5
-			preDeploymentSpeed = 2
-			minDeployment = 3000
-			deployedDiameter = 19.2
-			deploymentSpeed = 6
-			deploymentAlt = 1000
-			cutAlt = 0
-		}
-	}
-
-	MODULE
-	{
-		name = ModuleDragModifier
-		dragCubeName = SEMIDEPLOYED
-		dragModifier = 4 //1.25
-	}
-
-	MODULE
-	{
-		name = ModuleDragModifier
-		dragCubeName = DEPLOYED
-		dragModifier = 45 //12
 	}
 
 	MODULE
@@ -226,7 +161,8 @@ PART
 		name = ModuleDecouple
 		ejectionForce = 20
 		explosiveNodeID = top
-		staged = true
+		staged = false
+		menuName = Jettison Nose Unit
 	}
 
 	// MODULE
@@ -299,29 +235,10 @@ PART
 	}
 }
 
-@PART[ROC-MercuryRCSBDB]:AFTER[zzzRealismOverhaul]
+@PART[ROC-MercuryRCS2BDB]:AFTER[zzzRealismOverhaul]
 {
-	// RO forces all RealChuteModules to minDeploy 5000, deploy 1000,
-	// Get back our historical numbers
-	@MODULE[RealChuteModule]
-	{
-		@PARACHUTE
-		{
-			@minDeployment = 3000
-			@deploymentAlt = 1000
-		}
-	}
-	
 	@MODULE[ModuleToggleCrossfeed]
 	{
 		%crossfeedStatus = true
 	}
-}
-
-//	================================================================================
-//	Override RO global settings to get our temperatures back
-//	================================================================================
-@PART[ROC-MercuryRCSBDB]:AFTER[RealismOverhaul]
-{
-	@skinMaxTemp = 1144
 }

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/TU_Support_Mercury.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/TU_Support_Mercury.cfg
@@ -449,7 +449,7 @@ KSP_TEXTURE_SET:NEEDS[TexturesUnlimited]
 	%MODULE[SSTURecolorGUI] {}
 }
 
-@PART[ROC-MercuryAirbrakeBDB|ROC-MercuryRCSBDB|ROC-MercuryNoseCapBDB]:NEEDS[TexturesUnlimited]
+@PART[ROC-MercuryAirbrakeBDB|ROC-MercuryRCSBDB|ROC-MercuryRCS2BDB|ROC-MercuryNoseCapBDB]:NEEDS[TexturesUnlimited]
 {
 	MODULE
 	{

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/Waterfall_Support_MercuryBDB.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/Waterfall_Support_MercuryBDB.cfg
@@ -11,7 +11,7 @@
     }
 }
 
-@PART[ROC-MercuryRCSBDB]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
+@PART[ROC-MercuryRCSBDB|ROC-MercuryRCS2BDB]:BEFORE[ROWaterfall]:NEEDS[Waterfall]
 {
     ROWaterfall
     {


### PR DESCRIPTION
Thanks to new RealChute features allowing for a chute to ignore shielded status, the Mercury Parachute can be broken out into a separate part. Also as a QoL improvement, the Mercury recovery section now activates RCS on staging, with the decoupler acting as a manual toggle, and the Mercury Capsule icon has been changed to an RCS icon to make it clearer what staging it does.