### PR TITLE
Minor Apollo D2 fixes

### DIFF
--- a/GameData/ROCapsules/PartConfigs/Apollo D2/D2CommandModule.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo D2/D2CommandModule.cfg
@@ -106,7 +106,7 @@ PART
 	MODULE
 	{
 		name = AdjustableCoMShifter
-		DescentModeCoM = 0, 0, -0.2055
+		DescentModeCoM = 0, 0, 0.1
 	}
 
 	MODULE

--- a/GameData/ROCapsules/PartConfigs/Apollo D2/D2RCS.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo D2/D2RCS.cfg
@@ -71,6 +71,13 @@ PART
 		thrusterPower = 0.445
 		resourceFlowMode = STAGE_PRIORITY_FLOW
 		runningEffectName = running
+		//Skirt RCS does attitude control, we just need roll
+		enableX = true
+		enableY = true
+		enableZ = true
+		enableRoll = true
+		enablePitch = false
+		enableYaw = false
 		PROPELLANT	//1.78 O/F based on fuel load?
 		{
 			name = MMH


### PR DESCRIPTION
Make Apollo D2 reentry module offset CoM in the correct direction, and slightly less aggressive since D2 reentry module isn't as conic. Also set the RCS module control authority better.