### PR TITLE
Cargo part configs

### DIFF
--- a/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloSolar.cfg
+++ b/GameData/ROCapsules/PartConfigs/Apollo ETS/ApolloSolar.cfg
@@ -5,6 +5,7 @@ PART
 	author = CobaltWolf, capkirk
 
 	RSSROConfig = True
+	ROCargoConfig = True
 
 	//	============================================================================
 	//	Model and Dimensions
@@ -76,5 +77,11 @@ PART
 		area = 8.05
 		level = 3
 		type = tracking
+	}
+
+	MODULE
+	{
+		name = ModuleCargoPart
+		packedVolume = 240
 	}
 }

--- a/GameData/ROCapsules/PartConfigs/ApolloBDB/ApolloEVALightBDB.cfg
+++ b/GameData/ROCapsules/PartConfigs/ApolloBDB/ApolloEVALightBDB.cfg
@@ -5,6 +5,7 @@ PART
 	author = CobaltWolf, capkirk123
 
 	RSSROConfig = True
+	
 
 	//	============================================================================
 	//	Model and Dimensions
@@ -69,6 +70,12 @@ PART
 		endEventGUIName = #roLightOff	//Lights Off
 		actionGUIName = #roLightToggle	//Toggle Lights
 		defaultActionGroup = Light
+	}
+
+	MODULE
+	{
+		name = ModuleCargoPart
+		packedVolume = 8
 	}
 
 	//	============================================================================

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiRetroMEC.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiRetroMEC.cfg
@@ -5,6 +5,7 @@ PART
 	author = CobaltWolf, capkirk
 
 	RSSROConfig = True
+	ROCargoConfig = True
 
 	MODEL
 	{
@@ -73,5 +74,11 @@ PART
 		maxDistance = 50
 		falloff = 1.8
 		thrustTransformName = thrustTransform
+	}
+
+	MODULE
+	{
+		name = ModuleCargoPart
+		packedVolume = 40
 	}
 }

--- a/GameData/ROCapsules/PartConfigs/LEMBDB/LMPhaseB/LEMFoldingSNAP27BDB.cfg
+++ b/GameData/ROCapsules/PartConfigs/LEMBDB/LMPhaseB/LEMFoldingSNAP27BDB.cfg
@@ -4,6 +4,7 @@ PART
 	name = ROC-LEMFoldingSNAP27BDB
 	module = Part
 	author = CobaltWolf
+	ROCargoConfig = True
 	MODEL
 	{
 		model = ROCapsules/Assets/BDB/Apollo/bluedog_LM_RTG_Folding
@@ -86,6 +87,12 @@ PART
 		endEventGUIName = Retract Arm
 		actionGUIName = Toggle Arm
 		allowAnimationWhileShielded = False
+	}
+
+	MODULE
+	{
+		name = ModuleCargoPart
+		packedVolume = 166
 	}
 
 	RESOURCE

--- a/GameData/ROCapsules/PartConfigs/LEMBDB/LMPhaseB/LEMRackSNAP9BDB.cfg
+++ b/GameData/ROCapsules/PartConfigs/LEMBDB/LMPhaseB/LEMRackSNAP9BDB.cfg
@@ -3,6 +3,7 @@ PART
 	name = ROC-LEMRackSNAP9BDB
 	module = Part
 	author = CobaltWolf
+	ROCargoConfig = True
 	MODEL
 	{
 		model = ROCapsules/Assets/BDB/Apollo/bluedog_LM_RTG_Rack
@@ -76,6 +77,11 @@ PART
 		}
 	}
 
+	MODULE
+	{
+		name = ModuleCargoPart
+		packedVolume = 324
+	}
 
 	RESOURCE
 	{

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryPosigrade.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryPosigrade.cfg
@@ -6,6 +6,7 @@ PART
 	author = CobaltWolf
 
 	RSSROConfig = true
+	ROCargoConfig = True
 
 	MODEL
 	{
@@ -107,6 +108,12 @@ PART
 				key = 1 85 //https://www.sciencedirect.com/science/article/pii/S1000936121003319
 			}
 		}
+	}
+
+	MODULE
+	{
+		name = ModuleCargoPart
+		packedVolume = 2
 	}
 
 	PLUME

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryRetro.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryRetro.cfg
@@ -6,6 +6,7 @@ PART
 	author = CobaltWolf, capkirk
 
 	RSSROConfig = true
+	ROCargoConfig = True
 
 	MODEL
 	{
@@ -109,6 +110,12 @@ PART
 		jettisonedObjectMass = 0.01
 		jettisonForce = 0
 		jettisonDirection = 0 0 1
+	}
+
+	MODULE
+	{
+		name = ModuleCargoPart
+		packedVolume = 30
 	}
 
 	PLUME

--- a/GameData/ROCapsules/PartConfigs/Orion/OrionSolar.cfg
+++ b/GameData/ROCapsules/PartConfigs/Orion/OrionSolar.cfg
@@ -3,8 +3,9 @@ PART
 	name = ROC-OrionSolar
 	module = Part
 	author = DECQ
-	
+
 	RSSROConfig = True
+	ROCargoConfig = True
 
 	MODEL
 	{
@@ -50,5 +51,12 @@ PART
 		chargeRate = 2.75
 		retractable = false
 	}
+
+	MODULE
+	{
+		name = ModuleCargoPart
+		packedVolume = 390
+	}
+
 }
 


### PR DESCRIPTION
Actually configure some cargo parts. Set solar panels, SRMs, and miscellaneous small parts to be cargo parts.