### PR TITLE
Update GeminiLCM.cfg to fix antenna power subtraction applying to the regular Gemini capsule

### DIFF
--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiLCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiLCM.cfg
@@ -382,7 +382,7 @@ PART
 //	================================================================================
 //	Reduce power draw to compensate for RA antennas
 //	================================================================================
-@PART[ROC-GeminiCMBDB]:NEEDS[RealAntennas]
+@PART[ROC-GeminiLCMBDB]:NEEDS[RealAntennas]
 {
 	@MODULE[ModuleCommand]
 	{


### PR DESCRIPTION
Currently the GeminiLCM.cfg file subtracts the antenna power from the incorrect capsule. This leads to the regular Gemini capsule getting its antenna power draw subtraction applied twice. This PR fixes this issue by applying the power subtraction to the correct capsule.