### PR TITLE
Add a small amount of ablator to Mercury and Gemini CMs to deal with occlusion issues

### DIFF
--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiCM.cfg
@@ -331,7 +331,7 @@ PART
 	title = #rocGeminiCMBDBTitle	//Gemini Cabin
 	manufacturer = #roMfrMcDonnell
 	description = #rocGeminiCMBDBDesc
-	mass = 1.37586	//1412.01 kg - 26 kg (Batteries) - 18 kg (Antenna) - 3 kg (Habitat Atmosphere) - 20 kg (Other?) + 15.42 kg (Life Support Resources. LiOH included in inert mass)
+	mass = 1.36586	//1412.01 kg - 26 kg (Batteries) - 18 kg (Antenna) - 3 kg (Habitat Atmosphere) - 20 kg (Other?) + 15.42 kg (Life Support Resources. LiOH included in inert mass) - 10 kg (Ablator)
 	//1427.43 incl. LS mass compensation
 	dragModelType = default
 	maximum_drag = 0.20

--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/GeminiCM.cfg
@@ -353,13 +353,34 @@ PART
 	internalTempTag = Instruments
 	skinInsulationTag = True
 	paintEmissivityTag = 0.90	//high emissivity coating
-	skinTempOverride = 1750		//Raising this until we find a way to deal with excess heat flux
 
 	tags = capsule pod gemini
 
 	INTERNAL
 	{
 		name = ROC-GeminiBDB-Internal
+	}
+
+	//Add a small amount of ablator to the Mercury skin to stop it from overheating due to random occlusion bugs
+	//Theoretically the occlusion bugs could be fixed, but drag cubes are a goddamn insanity rune
+	MODULE
+	{
+		name = ModuleAblator
+		ablativeResource = Ablator
+		outputResource = CharredAblator
+		outputMult = 0	//Don't actually outpuy charred ablator, doesn't matter that much with an amount this small
+		lossExp = -6000
+		lossConst = 1.1	//Buffed to keep temp below 1255 K
+		pyrolysisLossFactor = 7800
+		ablationTempThresh = 750
+		reentryConductivity = 0.0065
+		infoTemp = 1255
+	}
+	RESOURCE
+	{
+		name = Ablator
+		maxAmount = 10
+		amount = 10
 	}
 
 	MODULE

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryCM.cfg
@@ -59,6 +59,8 @@ PART
 	//	================================================================================
 	//HS: 531 lbs
 	//	(Autoconfig tool assigns 197 lbs ablator, 157 lbs struct, for 354 lbs total)
+	//	(However, Mercury tends to run out of ablator, so add a little more)
+	//	(Going with 225 lbs ablator, 129 lbs structure, for 354 lbs total)
 	//	TPS: 354 lbs
 	//		Insulation: 46 lbs (dividing this up so HS mass agrees with autoconfig mass)
 	//		HS: 308 lbs
@@ -216,7 +218,7 @@ PART
 	description = The first American spacecraft. Carrying a single astronaut, it can be launched suborbital on a Redstone or into orbit on Atlas LV3B.
 	attachRules = 1,0,1,1,0
 	
-	mass = 0.61437	//693.10 kg - 5.13 kg (propellant tanks) - 87.48 kg (batteries) + 15.88 kg (LS resources) and 2 kg for trim (something adds 2 kg that I can't track down)
+	mass = 0.60937	//693.10 kg - 5.13 kg (propellant tanks) - 87.48 kg (batteries) + 15.88 kg (LS resources) - 5 kg (ablator) and - 2 kg for trim (something adds 2 kg that I can't track down)
 	//Subtract mass of propellant tanks and battery from base mass
 	//Life support mass will be subtracted when LS resources are patched
 	
@@ -250,6 +252,28 @@ PART
 	fuelCrossFeed = true
 
 	tags = mercury crew pod CM
+
+	//Add a small amount of ablator to the Mercury skin to stop it from overheating due to random occlusion bugs
+	//Theoretically the occlusion bugs could be fixed, but drag cubes are a goddamn insanity rune
+	MODULE
+	{
+		name = ModuleAblator
+		ablativeResource = Ablator
+		outputResource = CharredAblator
+		outputMult = 0	//Don't actually outpuy charred ablator, doesn't matter that much with an amount this small
+		lossExp = -6000
+		lossConst = 1.1	//Buffed to keep temp below 1255 K
+		pyrolysisLossFactor = 7800
+		ablationTempThresh = 750
+		reentryConductivity = 0.0065
+		infoTemp = 1255
+	}
+	RESOURCE
+	{
+		name = Ablator
+		maxAmount = 5
+		amount = 5
+	}
 
 	EFFECTS
 	{

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryHS.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryHS.cfg
@@ -31,7 +31,7 @@ PART
 	manufacturer = McDonnell Aircraft
 	description = Small 1.89m heatshield for the Mercury capsule. Place underneath, before adding the retropack. Does not include a fairing. Comes with a built in airbag for a nice comfy landing.
 	attachRules = 1,0,1,0,0
-	mass = 0.15156	//240.86 - 89.3 kg ablator
+	mass = 0.13880	//240.86 - 102.06 kg ablator
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.2
@@ -64,6 +64,20 @@ PART
 	//use new heat shield tagging system to configure the shield instead
 	heatShieldDiameter = 1.89
 	heatShieldTag = Mercury
-	resetHeatShieldAblator = true
+	resetHeatShieldAblator = false
 	resetHeatShieldMass = false
+
+	//Assign our own amount of Ablator, because the default amount tends to run out
+	RESOURCE
+	{
+		name = Ablator
+		maxAmount = 102.06	//~225 lbs
+		amount = 102.06
+	}
+	RESOURCE
+	{
+		name = CharredAblator
+		maxAmount = 102.06
+		amount = 0
+	}
 }


### PR DESCRIPTION
Since drag cubes are a cursed insanity rune and an alternate solution to this isn't likely to be forthcoming soon, just add a small amount of Ablator to the Mercury and Gemini command modules.

Tested, it seems to keep them just under their skin temperature limits even in the event of a worse-case scenario (steep reentry and intentionally bad pointing), without allowing them to re-enter without a heat shield.

Also slightly increase the ablator load in the Mercury Heat Shield because it tends to run out even on a normal re-entry.