### PR TITLE
Convert Mercury and Vostok to use module engine config too

### DIFF
--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryCM.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryCM.cfg
@@ -194,7 +194,7 @@ PART
 	buoyancyUseSine = False
 	CoPOffset = 0.0, 0.3, 0.0
 	CoLOffset = 0.0, -0.3, 0.0
-	CoMOffset = 0, -0.15, 0
+	CoMOffset = 0, -0.55, 0
 
 	// --Original values
 	// CenterOfBuoyancy = 0.0, 0.5, 0.0

--- a/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryRetro.cfg
+++ b/GameData/ROCapsules/PartConfigs/MercuryBDB/MercuryRetro.cfg
@@ -44,6 +44,8 @@ PART
 
 	tags = shepherd hermes solid booster decent retro motor engine mercury
 
+	engineType = TEM316
+
 	MODULE
 	{
 		name = ModuleEnginesRF
@@ -58,46 +60,6 @@ PART
 		engineAccelerationSpeed = 8.0
 		allowShutdown = False
 		fxOffset = 0, 0, 0.0
-	}
-
-	//Source: Solid rocket propulsion technology for de-orbiting spacecraft
-	//https://www.sciencedirect.com/science/article/pii/S1000936121003319
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		modded = false
-		configuration = MercuryRetro
-		CONFIG
-		{
-			name = MercuryRetro
-			minThrust = 5.1	//nominal thrust 5.1 kN
-			maxThrust = 5.1
-			heatProduction = 2
-
-			powerEffectName = Solid-Upper
-
-			PROPELLANT
-			{
-				name = PSPC
-				ratio = 1
-				DrawGauge = True
-			}
-			atmosphereCurve
-			{
-				key = 0 206
-				key = 1 85
-			}
-			chamberNominalTemp	 = 1400
-			maxEngineTemp = 1740
-		}
-	}
-
-	MODULE
-	{
-		name = ModuleFuelTanks
-		type = PSPC
-		volume = 12.57		//48.25 lbs propellant
-		basemass = -1
 	}
 
 	MODULE

--- a/GameData/ROCapsules/PartConfigs/Vostok/VostokService.cfg
+++ b/GameData/ROCapsules/PartConfigs/Vostok/VostokService.cfg
@@ -60,6 +60,9 @@ PART
 	skinTempTag = Aluminum
 	internalTempTag = Instruments
 
+	engineType = S5_4
+	ignoreMass = True	//Obviously, this contains a lot more than just the engine. Don't use engine weight
+
 	//	============================================================================
 	//	Animations and Textures
 	//	============================================================================
@@ -152,39 +155,6 @@ PART
 		maxDistance = 30
 		falloff = 1.7
 		thrustTransformName = thrustTransform
-	}
-
-	MODULE
-	{
-		name = ModuleEngineConfigs
-		type = ModuleEngines
-		configuration = S5.4
-		modded = false
-
-		CONFIG
-		{
-			name = S5.4
-			minThrust = 15.83
-			maxThrust = 15.83
-			heatProduction = 100
-			ignitions = 1	//only 1 start provided
-			PROPELLANT
-			{
-				name = AK20
-				ratio = 0.6360
-				DrawGauge = True
-			}
-			PROPELLANT
-			{
-				name = Tonka250
-				ratio = 0.3640
-			}
-			atmosphereCurve
-			{
-				key = 0 266
-				key = 1 112
-			}
-		}
 	}
 
 	//Vostok had two RCS systems. Deorbit orientation thrusters ran off main engine gas generator
@@ -321,6 +291,15 @@ PART
 	}
 }
 
+//	================================================================================
+//	Stop MEC from overriding our description
+//	================================================================================
+@PART[ROC-VostokService]:AFTER[RealismOverhaulEngines]
+{
+	%title = Vostok/Voskhod Service Module
+	%manufacturer = #roMfrOKB1
+	%description = A service module with batteries a simple engine AK20/Tonka250 engine that has only 1 ignition. This is the same service module that you use for Vostok, Voskhod, and Zenit. Attach the Decoupler to the Descent Module first and attach this to the bottom of the Descent Module.
+}
 //	================================================================================
 //	Configure RealAntennas
 //	================================================================================

--- a/GameData/ROCapsules/PartConfigs/Vostok/VostokService.cfg
+++ b/GameData/ROCapsules/PartConfigs/Vostok/VostokService.cfg
@@ -296,9 +296,9 @@ PART
 //	================================================================================
 @PART[ROC-VostokService]:AFTER[RealismOverhaulEngines]
 {
-	%title = Vostok/Voskhod Service Module
+	%title = Vostok/Voskhod/Zenit Service Module
 	%manufacturer = #roMfrOKB1
-	%description = A service module with batteries a simple engine AK20/Tonka250 engine that has only 1 ignition. This is the same service module that you use for Vostok, Voskhod, and Zenit. Attach the Decoupler to the Descent Module first and attach this to the bottom of the Descent Module.
+	%description = A service module with batteries a simple de-orbit engine that has only 1 ignition. This is the same service module that you use for Vostok, Voskhod, and Zenit. Attach the Decoupler to the Descent Module first and attach this to the bottom of the Descent Module.
 }
 //	================================================================================
 //	Configure RealAntennas


### PR DESCRIPTION
Convert the Mercury Retros and Vostok Service Module to use Module Engine Config, now with testflight configs.

Also adjust the Mercury CM center of mass so it doesn't spin out of control on retro failure.

Needs https://github.com/KSP-RO/RealismOverhaul/pull/3053