### PR TITLE
Fix GATV docking port fairing decouple direction

### DIFF
--- a/GameData/ROCapsules/PartConfigs/GeminiBDB/AgenaFairing.cfg
+++ b/GameData/ROCapsules/PartConfigs/GeminiBDB/AgenaFairing.cfg
@@ -79,7 +79,8 @@ PART
 		isOmniDecoupler = false
 		ejectionForce = 50
 		explosiveNodeID = Nose_Node
-		explosiveDir = 0, 0, -1 // example
+		automaticDir = false
+		explosiveDir = 1, 0, 0
 	}
 
 }


### PR DESCRIPTION
`explosiveDir` is relative to the Part's transform, not the attach node's; and it doesn't do anything without `automaticDir` set to false.